### PR TITLE
[HTM-332] synchronize the featureinfo buffer distance with the default value from the API

### DIFF
--- a/projects/core/src/lib/components/feature-info/feature-info.service.ts
+++ b/projects/core/src/lib/components/feature-info/feature-info.service.ts
@@ -14,7 +14,11 @@ export class FeatureInfoService {
 
   private static LOAD_FEATURE_INFO_ERROR = $localize `Could not load feature info`;
 
-  private static DEFAULT_DISTANCE = 10;
+  /**
+   * default buffer distance for feature info requests in native CRS units, eg. m for EPSG:28992 or EPSG:3857.
+   * For EPSG:4326 0.00004 would be a good value.
+   */
+  private static DEFAULT_DISTANCE = 4;
 
   constructor(
     private store$: Store,


### PR DESCRIPTION
Both the backend as well as the API spec have a value of 4, not 10:

https://github.com/B3Partners/tailormap-api/blob/46972f3fc7ff85d158f0e0e361bb30f0fd110573/src/main/java/nl/b3p/tailormap/api/controller/FeaturesController.java#L157

https://github.com/B3Partners/tailormap-api/blob/46972f3fc7ff85d158f0e0e361bb30f0fd110573/src/main/resources/tailormap-api.yaml#L509-L515

resolves HTM-332