### PR TITLE
[HTM-426] Add exports for color-picker and icon-picker to make npm build pass

### DIFF
--- a/projects/shared/src/lib/components/index.ts
+++ b/projects/shared/src/lib/components/index.ts
@@ -6,3 +6,5 @@ export * from './error-message';
 export * from './split-button';
 export * from './confirm-dialog';
 export * from './panel-resizer';
+export * from './color-picker/color-picker.component';
+export * from './icon-picker/icon-picker.component';

--- a/projects/shared/src/lib/services/index.ts
+++ b/projects/shared/src/lib/services/index.ts
@@ -5,3 +5,4 @@ export * from './popover/popover.service';
 export * from './popover/models/popover-position.enum';
 export * from './overlay/overlay.service';
 export * from './overlay/overlay-ref';
+export * from './overlay/overlay/overlay.component';


### PR DESCRIPTION
resolves HTM-426