### PR TITLE
[HTM-336] Expose the nginx stub_status

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - proxied
     networks:
       - tailormap-viewer
+    expose:
+      - "8080"
     environment:
       - "API_PROXY_ENABLED=${API_PROXY_ENABLED:-true}"
       - "API_PROXY_URL=${API_PROXY_URL:-http://api:8080/api/}"
@@ -56,6 +58,24 @@ services:
       traefik.http.services.tailormap-snapshot.loadbalancer.server.port: 80
       traefik.enable: true
     restart: unless-stopped
+
+
+  web-status:
+    profiles:
+      - proxied
+    depends_on:
+      - web-proxied
+    expose:
+      - "9113"
+    image: nginx/nginx-prometheus-exporter:0.10.0
+    environment:
+      SCRAPE_URI: http://web-proxied:8080/stub_status
+      NGINX_RETRIES: 3
+      TELEMETRY_PATH: /metrics
+    networks:
+      - tailormap-viewer
+    labels:
+      traefik.enable: false
 
 
   api:

--- a/docker/web/nginx.conf
+++ b/docker/web/nginx.conf
@@ -45,4 +45,13 @@ http {
     #api include conf.d/api-proxy.conf;
     #admin include conf.d/admin-proxy.conf;
   }
+
+  server {
+    listen 8080;
+    listen [::]:8080;
+
+    location /stub_status {
+      stub_status;
+    }
+  }
 }


### PR DESCRIPTION
Expose the nginx stub_status to a converter that then provides prometheus metrics. Will provide something like below:

```
mark @ mark-desktop /tmp
└─ $ ▶ curl http://localhost:9113/metrics
# HELP nginx_connections_accepted Accepted client connections
# TYPE nginx_connections_accepted counter
nginx_connections_accepted 37
# HELP nginx_connections_active Active client connections
# TYPE nginx_connections_active gauge
nginx_connections_active 3
# HELP nginx_connections_handled Handled client connections
# TYPE nginx_connections_handled counter
nginx_connections_handled 37
# HELP nginx_connections_reading Connections where NGINX is reading the request header
# TYPE nginx_connections_reading gauge
nginx_connections_reading 0
# HELP nginx_connections_waiting Idle client connections
# TYPE nginx_connections_waiting gauge
nginx_connections_waiting 2
# HELP nginx_connections_writing Connections where NGINX is writing the response back to the client
# TYPE nginx_connections_writing gauge
nginx_connections_writing 1
# HELP nginx_http_requests_total Total http requests
# TYPE nginx_http_requests_total counter
nginx_http_requests_total 50
# HELP nginx_up Status of the last metric scrape
# TYPE nginx_up gauge
nginx_up 1
# HELP nginxexporter_build_info Exporter build information
# TYPE nginxexporter_build_info gauge
nginxexporter_build_info{commit="7a03d0314425793cf4001f0d9b0b2cfd19563433",date="2021-12-21T19:24:34Z",version="0.10.0"} 1

```