### PR TITLE
Adjust mouse coordinate sizes, use tabular numbers

### DIFF
--- a/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.css
+++ b/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.css
@@ -1,6 +1,7 @@
 .mouse-coordinates {
   font-weight: bold;
   font-size: 14px;
+  font-variant-numeric: tabular-nums;
   display: flex;
   align-items: center;
   border-radius: 3px;

--- a/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.css
+++ b/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.css
@@ -8,15 +8,6 @@
   background-color: var(--primary-color-background-0_8);
 }
 
-.mouse-coordinates > div {
-  padding: 8px;
-  width: 100px;
-}
-
-.mouse-coordinates__left {
-  text-align: right;
-}
-
-.mouse-coordinates__right {
-  text-align: left;
+.mouse-coordinates__coordinate {
+  margin: 8px;
 }

--- a/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.html
+++ b/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.html
@@ -4,11 +4,9 @@
      (mouseenter)="isOverCoordinates(true)"
      (mouseout)="isOverCoordinates(false)"
      *ngIf="coordinates$ | async as coordinates">
-  <div class="mouse-coordinates__left"
-       *ngIf="coordinates[0]"
-       [style.width]="estimateWidth(coordinates[0])">{{coordinates[0]}}</div>
+  <span class="mouse-coordinates__coordinate"
+       *ngIf="coordinates[0]">{{coordinates[0]}}</span>
   <span *ngIf="coordinates[0] && coordinates[1]">|</span>
-  <div class="mouse-coordinates__right"
-       *ngIf="coordinates[1]"
-       [style.width]="estimateWidth(coordinates[1])">{{coordinates[1]}}</div>
+  <span class="mouse-coordinates__coordinate"
+       *ngIf="coordinates[1]">{{coordinates[1]}}</span>
 </div>

--- a/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.ts
+++ b/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.ts
@@ -36,7 +36,7 @@ export class MouseCoordinatesComponent implements OnInit, OnDestroy {
   }
 
   public estimateWidth(coordinate: string) {
-    return `${coordinate.length * 10}px`;
+    return `${coordinate.length + 1}ch`;
   }
 
   public ngOnDestroy() {

--- a/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.ts
+++ b/projects/core/src/lib/components/toolbar/mouse-coordinates/mouse-coordinates.component.ts
@@ -35,10 +35,6 @@ export class MouseCoordinatesComponent implements OnInit, OnDestroy {
       );
   }
 
-  public estimateWidth(coordinate: string) {
-    return `${coordinate.length + 1}ch`;
-  }
-
   public ngOnDestroy() {
     this.destroyed.next(null);
     this.destroyed.complete();


### PR DESCRIPTION
This stops the coordinates from jittering when moving the mouse around, and the size of the box being a guess.
<details>
<summary>Before and after</summary>

![before](https://user-images.githubusercontent.com/488734/186118505-f7998c1b-4f77-41d2-8020-c3aaa21e6136.gif)
![after](https://user-images.githubusercontent.com/488734/186120550-453aa48a-d073-40d6-8d40-e1780284b761.gif)

</details>