### PR TITLE
[HTM-445] Bump NodeJS from 16.16.0 to 16.17.0

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -2,7 +2,7 @@ name: Test and deploy
 
 env:
   # Keep this in sync with Dockerfile version
-  NODE_VERSION: "16.16.0"
+  NODE_VERSION: "16.17.0"
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note when updating this version also update the version in the workflow files
-FROM node:16.16.0 AS builder
+FROM node:16.17.0 AS builder
 
 ARG BASE_HREF=/
 


### PR DESCRIPTION
see https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#16.17.0

resolves HTM-445