### PR TITLE
[HTM-451][HTM-452] use as-is sorting for the feature info rendering

### DIFF
--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.html
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.html
@@ -9,7 +9,7 @@
   <div class="feature-info" *ngIf="currentFeature$ | async as currentFeature">
     <div class="content">
       <h2>{{currentFeature.layer.title}}</h2>
-      <div *ngFor="let a of getAttributes(currentFeature) | keyvalue" class="row">
+      <div *ngFor="let a of getAttributes(currentFeature) | keyvalue: asIsOrder" class="row">
         <strong>{{a.value.label}}</strong>
         {{a.value.value}}
       </div>

--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.html
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.html
@@ -9,9 +9,9 @@
   <div class="feature-info" *ngIf="currentFeature$ | async as currentFeature">
     <div class="content">
       <h2>{{currentFeature.layer.title}}</h2>
-      <div *ngFor="let a of getAttributes(currentFeature) | keyvalue: asIsOrder" class="row">
-        <strong>{{a.value.label}}</strong>
-        {{a.value.value}}
+      <div *ngFor="let att of currentFeature.sortedAttributes" class="row">
+        <strong>{{att.label}}</strong>
+        {{att.attributeValue}}
       </div>
     </div>
     <div class="buttons">

--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.spec.ts
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.spec.ts
@@ -12,12 +12,14 @@ import { FeatureInfoModel } from '../models/feature-info.model';
 import { showNextFeatureInfoFeature, showPreviousFeatureInfoFeature } from '../state/feature-info.actions';
 
 const getFeatureInfo = (updated?: boolean): FeatureInfoModel => {
-  const col1 = getColumnMetadataModel();
-  const col2 = getColumnMetadataModel({ key: 'prop2', alias: 'Property 2' });
   return {
-    feature: { __fid: updated ? '6' : '1', attributes: { prop: 'test', prop2: 'another test', fid: updated ? '6' : '1' } },
-    columnMetadata: new Map([[ col1.key, col1 ], [ col2.key, col2 ]]),
+    geometry: null,
     layer: getAppLayerModel(),
+    sortedAttributes: [
+      { key: 'prop', attributeValue: 'test', label: 'Property' },
+      { key: 'prop2', attributeValue: 'another test', label: 'Property 2' },
+      { key: 'fid', attributeValue: updated ? '6' : '1', label: 'fid' },
+    ],
   };
 };
 

--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.ts
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.ts
@@ -85,4 +85,10 @@ export class FeatureInfoDialogComponent implements OnInit, OnDestroy {
   public isNextDisabled() {
     return this.totalFeatures <= 1 || this.currentSelected === this.totalFeatures - 1;
   }
+
+  // keyA and keyB are KeyValue from the #getAttributes map, returning 1 should prevent alphabetical sorting
+  // inspired by https://github.com/angular/angular/issues/42490#issuecomment-1206562995
+  public asIsOrder(): number {
+    return 0;
+  }
 }

--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.ts
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.ts
@@ -8,7 +8,6 @@ import {
   expandCollapseFeatureInfoDialog, hideFeatureInfoDialog, showNextFeatureInfoFeature, showPreviousFeatureInfoFeature,
 } from '../state/feature-info.actions';
 import { FeatureInfoModel } from '../models/feature-info.model';
-import { FeatureAttributeTypeEnum } from '@tailormap-viewer/api';
 
 @Component({
   selector: 'tm-feature-info-dialog',
@@ -65,19 +64,6 @@ export class FeatureInfoDialogComponent implements OnInit, OnDestroy {
     this.destroyed.complete();
   }
 
-  public getAttributes(feature: FeatureInfoModel): ReadonlyMap<string, { label: string; value: string | number | boolean }> {
-    const attr = new Map();
-    Object.keys(feature.feature.attributes).forEach(key => {
-      const metadata = feature.columnMetadata.get(key);
-      if (metadata?.type === FeatureAttributeTypeEnum.GEOMETRY) {
-        return;
-      }
-      const label = metadata?.alias || key;
-      attr.set(key, { value: feature.feature.attributes[key], label });
-    });
-    return attr as ReadonlyMap<string, { label: string; value: string | number | boolean }>;
-  }
-
   public isBackDisabled() {
     return this.totalFeatures <= 1 || this.currentSelected === 0;
   }
@@ -86,9 +72,4 @@ export class FeatureInfoDialogComponent implements OnInit, OnDestroy {
     return this.totalFeatures <= 1 || this.currentSelected === this.totalFeatures - 1;
   }
 
-  // keyA and keyB are KeyValue from the #getAttributes map, returning 1 should prevent alphabetical sorting
-  // inspired by https://github.com/angular/angular/issues/42490#issuecomment-1206562995
-  public asIsOrder(): number {
-    return 0;
-  }
 }

--- a/projects/core/src/lib/components/feature-info/helpers/feature-info.helper.ts
+++ b/projects/core/src/lib/components/feature-info/helpers/feature-info.helper.ts
@@ -2,6 +2,8 @@ import { FeatureInfoResponseModel } from '../models/feature-info-response.model'
 import { FeatureInfoModel } from '../models/feature-info.model';
 import { FeatureAttributeTypeEnum } from '@tailormap-viewer/api';
 import { FeatureHelper } from '../../../shared/helpers/feature.helper';
+import { FeatureInfoFeatureModel } from '../models/feature-info-feature.model';
+import { FeatureInfoColumnMetadataModel } from '../models/feature-info-column-metadata.model';
 
 export class FeatureInfoHelper {
 
@@ -9,18 +11,18 @@ export class FeatureInfoHelper {
     return featureInfo.reduce((totalCount, fI) => totalCount + fI.features.length, 0);
   }
 
-  public static getGeometryForFeatureInfoFeature(feature?: FeatureInfoModel | null): string | null {
+  public static getGeometryForFeatureInfoFeature(feature: FeatureInfoFeatureModel, columnMetadata: FeatureInfoColumnMetadataModel[]): string | null {
     if (!feature) {
       return null;
     }
-    if (feature.feature.geometry) {
-      return feature.feature.geometry;
+    if (feature.geometry) {
+      return feature.geometry;
     }
-    const geomAttribute = Array.from(feature.columnMetadata.values()).find(c => c.type === FeatureAttributeTypeEnum.GEOMETRY);
+    const geomAttribute = columnMetadata.find(c => c.type === FeatureAttributeTypeEnum.GEOMETRY);
     if (!geomAttribute) {
       return null;
     }
-    return FeatureHelper.getGeometryForFeature(feature.feature, geomAttribute.key);
+    return FeatureHelper.getGeometryForFeature(feature, geomAttribute.key);
   }
 
 }

--- a/projects/core/src/lib/components/feature-info/helpers/feature-info.helper.ts
+++ b/projects/core/src/lib/components/feature-info/helpers/feature-info.helper.ts
@@ -1,5 +1,4 @@
 import { FeatureInfoResponseModel } from '../models/feature-info-response.model';
-import { FeatureInfoModel } from '../models/feature-info.model';
 import { FeatureAttributeTypeEnum } from '@tailormap-viewer/api';
 import { FeatureHelper } from '../../../shared/helpers/feature.helper';
 import { FeatureInfoFeatureModel } from '../models/feature-info-feature.model';

--- a/projects/core/src/lib/components/feature-info/models/feature-info.model.ts
+++ b/projects/core/src/lib/components/feature-info/models/feature-info.model.ts
@@ -1,8 +1,7 @@
-import { AppLayerModel, ColumnMetadataModel, FeatureModel } from '@tailormap-viewer/api';
+import { AppLayerModel } from '@tailormap-viewer/api';
 
 export interface FeatureInfoModel {
-  feature: FeatureModel;
-  columnMetadata: ColumnMetadataModel[];
   layer: AppLayerModel;
   sortedAttributes: Array<{ label: string; attributeValue: any; key: string }>;
+  geometry: string | null;
 }

--- a/projects/core/src/lib/components/feature-info/models/feature-info.model.ts
+++ b/projects/core/src/lib/components/feature-info/models/feature-info.model.ts
@@ -2,6 +2,7 @@ import { AppLayerModel, ColumnMetadataModel, FeatureModel } from '@tailormap-vie
 
 export interface FeatureInfoModel {
   feature: FeatureModel;
-  columnMetadata: Map<string, ColumnMetadataModel>;
+  columnMetadata: ColumnMetadataModel[];
   layer: AppLayerModel;
+  sortedAttributes: Array<{ label: string; attributeValue: any; key: string }>;
 }

--- a/projects/core/src/lib/components/feature-info/state/feature-info.selectors.ts
+++ b/projects/core/src/lib/components/feature-info/state/feature-info.selectors.ts
@@ -42,10 +42,9 @@ export const selectFeatureInfoList = createSelector(
       });
       const attributeOrder = columnMetadata.map(c => c.key);
       featureInfoModels.push({
-        feature,
-        columnMetadata,
         layer,
         sortedAttributes: attributes.sort(ArrayHelper.getArraySorter('key', attributeOrder)),
+        geometry: FeatureInfoHelper.getGeometryForFeatureInfoFeature(feature, columnMetadata) || null,
       });
     });
     return featureInfoModels;
@@ -72,10 +71,10 @@ export const selectCurrentlySelectedFeatureGeometry = createSelector(
   selectFeatureInfoDialogVisible,
   selectCurrentlySelectedFeature,
   (dialogVisible, feature) => {
-    if (!dialogVisible) {
+    if (!dialogVisible || !feature) {
       return null;
     }
-    return FeatureInfoHelper.getGeometryForFeatureInfoFeature(feature);
+    return feature.geometry;
   },
 );
 

--- a/projects/core/src/lib/map/state/map.selectors.ts
+++ b/projects/core/src/lib/map/state/map.selectors.ts
@@ -1,7 +1,7 @@
 import { MapSettingsModel, MapState, mapStateKey } from './map.state';
 import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { AppLayerModel, LayerTreeNodeModel, ServiceModel } from '@tailormap-viewer/api';
-import { TreeModel } from '@tailormap-viewer/shared';
+import { ArrayHelper, TreeModel } from '@tailormap-viewer/shared';
 import { LayerTreeNodeHelper } from '../helpers/layer-tree-node.helper';
 import { AppLayerWithServiceModel, ExtendedLayerTreeNodeModel } from '../models';
 
@@ -90,14 +90,7 @@ export const selectOrderedVisibleLayersWithServices = createSelector(
   (layers, orderedLayerIds) => {
     return layers
       .filter(l => orderedLayerIds.includes(l.id))
-      .sort((l1, l2) => {
-        const idx1 = orderedLayerIds.findIndex(id => l1.id === id);
-        const idx2 = orderedLayerIds.findIndex(id => l2.id === id);
-        if (idx1 === idx2) {
-          return 0;
-        }
-        return idx1 > idx2 ? 1 : -1;
-      });
+      .sort(ArrayHelper.getArraySorter('id', orderedLayerIds));
   },
 );
 
@@ -107,7 +100,7 @@ export const selectOrderedVisibleBackgroundLayers = createSelector(
   (layers, orderedLayerIds) => {
     return layers
       .filter(l => orderedLayerIds.includes(l.id))
-      .sort(l => orderedLayerIds.findIndex(id => l.id === id));
+      .sort(ArrayHelper.getArraySorter('id', orderedLayerIds));
   },
 );
 

--- a/projects/shared/src/lib/helpers/array.helper.spec.ts
+++ b/projects/shared/src/lib/helpers/array.helper.spec.ts
@@ -1,0 +1,19 @@
+import { ArrayHelper } from './array.helper';
+
+describe('ArrayHelper', () => {
+
+  test('arrayEquals', () => {
+    expect(ArrayHelper.arrayEquals([], [])).toEqual(true);
+    expect(ArrayHelper.arrayEquals(['a'], ['a'])).toEqual(true);
+    expect(ArrayHelper.arrayEquals(['a'], [ 'a', 'b' ])).toEqual(false);
+    expect(ArrayHelper.arrayEquals(['a'], 'a' as any)).toEqual(false);
+  });
+
+  test('getArraySorter', () => {
+    const source = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const order = [ 'b', 'c', 'a' ];
+    const sorted = source.sort(ArrayHelper.getArraySorter('id', order));
+    expect(sorted).toMatchObject([{ id: 'b' }, { id: 'c' }, { id: 'a' }]);
+  });
+
+});

--- a/projects/shared/src/lib/helpers/array.helper.ts
+++ b/projects/shared/src/lib/helpers/array.helper.ts
@@ -7,4 +7,21 @@ export class ArrayHelper {
       a.every((val, index) => val === b[index]);
   }
 
+  public static getArraySorter<T>(findByProp: keyof T, orderedItems: any[]) {
+    return (l1: T, l2: T) => {
+      const idx1 = orderedItems.findIndex(sortProp => l1[findByProp] === sortProp);
+      const idx2 = orderedItems.findIndex(sortProp => l2[findByProp] === sortProp);
+      if (idx1 === idx2) {
+        return 0;
+      }
+      if (idx1 === -1) {
+        return 1;
+      }
+      if (idx2 === -1) {
+        return -1;
+      }
+      return idx1 > idx2 ? 1 : -1;
+    };
+  }
+
 }


### PR DESCRIPTION
instead of alphabetically sorting the the attributes by name...

The collection of configured attributes is sorted according to the `list_index`, see:

https://github.com/B3Partners/tailormap-persistence/blob/e1dd76a7ca0b0a1a7d280adf0f2eda1ab5e66720/src/main/java/nl/tailormap/viewer/config/app/ApplicationLayer.java#L89-L90

before:
![image](https://user-images.githubusercontent.com/1165786/187958319-20b570ab-1d1b-47a5-b721-1e75aa50f42b.png)

after:
![image](https://user-images.githubusercontent.com/1165786/187958139-4398a426-ed66-45e3-a85f-afa00f31f828.png)

resolves HTM-451, HTM-452