### PR TITLE
Use URLSearchParams forEach() instead of entries()

### DIFF
--- a/projects/shared/src/lib/helpers/url.helper.ts
+++ b/projects/shared/src/lib/helpers/url.helper.ts
@@ -17,11 +17,12 @@ export class UrlHelper {
 
   public static getParamCaseInsensitive(url: URL, param: string): string | null {
     param = param.toLowerCase();
-    for(const entry of url.searchParams.entries()) {
-      if(entry[0].toLowerCase() === param) {
-        return entry[1];
+    let result = null;
+    url.searchParams.forEach((value, key) => {
+      if(key.toLowerCase() === param) {
+        result = value;
       }
-    }
-    return null;
+    });
+    return result;
   }
 }


### PR DESCRIPTION
Fixes

```
Error: projects/shared/src/lib/helpers/url.helper.ts:20:41 - error TS2339: Property 'entries' does not exist on type 'URLSearchParams'.
```