### PR TITLE
Revert to old docker-compose for pulling snapshot images on main branch deployment

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -129,8 +129,13 @@ jobs:
 
       - name: 'Update main deployment using Docker Compose'
         if: ${{ github.ref == 'refs/heads/main' }}
+        # use the old/python docker-compose for pulling to prevent errors like https://github.com/docker/buildx/issues/764
+        # WARNING: Some service image(s) must be built from source by running:
+        #    docker compose build %s db web-proxied
+        # error during connect: Post "http://docker.example.com/v1.41/images/create?fromImage=nginx%2Fnginx-prometheus-exporter&tag=0.10.0":
+        # command [ssh -l github-docker-actions -- *** docker system dial-stdio] has exited with signal: killed, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
         run: |
-          docker compose -f docker-compose.yml --profile proxied --profile full pull
+          docker-compose -f docker-compose.yml --profile proxied --profile full pull -q
           DB_PORT=127.0.0.1:55432:5432 HOST=${{ secrets.DEPLOY_HOST_SNAPSHOT }} docker compose -f docker-compose.yml -f docker-compose-db-ports.yml --profile proxied --profile full up -d --pull=always
 
       - name: 'Update pull request deployment using Docker Compose'


### PR DESCRIPTION
to prevent errors thet say:

```
WARNING: Some service image(s) must be built from source by running:
    docker compose build %s db web-proxied
error during connect: Post "http://docker.example.com/v1.41/images/create?fromImage=nginx%2Fnginx-prometheus-exporter&tag=0.10.0": command [ssh -l github-docker-actions -- *** docker system dial-stdio] has exited with signal: killed, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
```