### PR TITLE
[HTM-322, HTM-466] Enable sentry

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -129,6 +129,11 @@ jobs:
 
       - name: 'Update main deployment using Docker Compose'
         if: ${{ github.ref == 'refs/heads/main' }}
+        env:
+          DB_PORT: "127.0.0.1:55432:5432"
+          HOST: ${{ secrets.DEPLOY_HOST_SNAPSHOT }}
+          API_SENTRY_DSN: ${{ secrets.API_SENTRY_DSN }}
+          VIEWER_SENTRY_DSN: ${{ secrets.VIEWER_SENTRY_DSN }}
         # use the old/python docker-compose for pulling to prevent errors like https://github.com/docker/buildx/issues/764
         # WARNING: Some service image(s) must be built from source by running:
         #    docker compose build %s db web-proxied
@@ -136,14 +141,17 @@ jobs:
         # command [ssh -l github-docker-actions -- *** docker system dial-stdio] has exited with signal: killed, please make sure the URL is valid, and Docker 18.09 or later is installed on the remote host: stderr=
         run: |
           docker-compose -f docker-compose.yml --profile proxied --profile full pull -q
-          DB_PORT=127.0.0.1:55432:5432 HOST=${{ secrets.DEPLOY_HOST_SNAPSHOT }} docker compose -f docker-compose.yml -f docker-compose-db-ports.yml --profile proxied --profile full up -d --pull=always
+          docker compose -f docker-compose.yml -f docker-compose-db-ports.yml --profile proxied --profile full up -d --pull=always
 
       - name: 'Update pull request deployment using Docker Compose'
         if: ${{ steps.find-pr.outputs.number }}
+        env:
+          NAME: ${{ env.VERSION_TAG }}
+          HOST: ${{ secrets.DEPLOY_HOST_SNAPSHOT }}
+          VIEWER_SENTRY_DSN: ${{ secrets.VIEWER_SENTRY_DSN }}
         run: |
-          export NAME=${{ env.VERSION_TAG }}
           docker compose -f docker-compose-pr.yml --project-name tailormap-snapshot-${NAME} pull
-          HOST=${{ secrets.DEPLOY_HOST_SNAPSHOT }} docker compose -f docker-compose-pr.yml --project-name tailormap-snapshot-${NAME} up -d --pull=always
+          docker compose -f docker-compose-pr.yml --project-name tailormap-snapshot-${NAME} up -d --pull=always
 
       - name: 'Create GitHub deployment'
         if: success()

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY docker/web/nginx.conf /etc/nginx/nginx.conf
 COPY docker/web/api-proxy.conf.template /etc/nginx/templates/api-proxy.conf.template
 COPY docker/web/admin-proxy.conf.template /etc/nginx/templates/admin-proxy.conf.template
 COPY docker/web/enable-proxies.sh /docker-entrypoint.d/enable-proxies.sh
+COPY docker/web/configure-sentry.sh /docker-entrypoint.d/99-configure-sentry.sh
 
 EXPOSE 80
 

--- a/bin/prebuild.js
+++ b/bin/prebuild.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const {version: appVersion} = require('../package.json')
 
-const info = git.gitDescribeSync({longSemver: true});
+const info = git.gitDescribeSync({longSemver: true, customArguments: [ '--abbrev=40' ]});
 fs.mkdirp(path.join(__dirname, '../generated/'));
 const file = path.resolve(__dirname, '../generated/', 'version.json');
 

--- a/docker-compose-pr.yml
+++ b/docker-compose-pr.yml
@@ -25,6 +25,7 @@ services:
     environment:
       - API_PROXY_ENABLED=false
       - ADMIN_PROXY_ENABLED=false
+      - "SENTRY_DSN=${VIEWER_SENTRY_DSN:-}"
     labels:
       - "traefik.http.routers.tailormap-snapshot-${NAME}.rule=Host(`${HOST:-localhost}`) && PathPrefix(`${BASE_HREF}`)"
       - traefik.http.routers.tailormap-snapshot-${NAME}.tls=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - "ADMIN_PROXY_ENABLED=${ADMIN_PROXY_ENABLED:-true}"
       - "ADMIN_PROXY_URL=${ADMIN_PROXY_URL:-http://admin:8080/admin/}"
       - "ADMIN_PROXY_HOST=${ADMIN_PROXY_HOST:-localhost}"
+      - "SENTRY_DSN=${VIEWER_SENTRY_DSN:-}"
     labels:
       traefik.enable: false
     restart: unless-stopped
@@ -53,6 +54,7 @@ services:
       - "ADMIN_PROXY_ENABLED=${ADMIN_PROXY_ENABLED:-true}"
       - "ADMIN_PROXY_URL=${ADMIN_PROXY_URL:-http://admin:8080/admin/}"
       - "HOST=${HOST:-localhost}"
+      - "SENTRY_DSN=${VIEWER_SENTRY_DSN:-}"
     labels:
       traefik.http.routers.tailormap-snapshot.rule: "Host(`${HOST:-localhost}`)"
       traefik.http.routers.tailormap-snapshot.tls: "true"
@@ -92,6 +94,9 @@ services:
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db/tailormap
       DB_PASSWORD: ${TAILORMAP_DB_PASSWORD:-tailormap}
+      SENTRY_DSN: ${API_SENTRY_DSN:-}
+      # Sample 20% of API requests for now.
+      SENTRY_TRACES_SAMPLE_RATE: 0.2
     labels:
       traefik.enable: false
     restart: unless-stopped

--- a/docker/web/configure-sentry.sh
+++ b/docker/web/configure-sentry.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -i "s!@SENTRY_DSN@!${SENTRY_DSN}!g" /usr/share/nginx/html/index.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@ngrx/effects": "^14.1.0",
         "@ngrx/store": "^14.1.0",
         "@ngrx/store-devtools": "^14.1.0",
+        "@sentry/angular": "^7.14.1",
+        "@sentry/tracing": "^7.14.1",
         "html2canvas": "^1.4.1",
         "jspdf": "^2.5.1",
         "luxon": "^2.5.0",
@@ -4446,6 +4448,126 @@
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
+    },
+    "node_modules/@sentry/angular": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-7.14.1.tgz",
+      "integrity": "sha512-GaqvZE+yYwuldyuk+Fu0gNO3HTJiu1UG5GZBszYonr9citdy6dRDF/QI97bkaJh1iKrz5w8PkiL/zxQOFmsTtw==",
+      "dependencies": {
+        "@sentry/browser": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "@angular/common": "10.x || 11.x || 12.x || 13.x || 14.x",
+        "@angular/core": "10.x || 11.x || 12.x || 13.x || 14.x",
+        "@angular/router": "10.x || 11.x || 12.x || 13.x || 14.x",
+        "rxjs": "^6.5.5 || ^7.x"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.1.tgz",
+      "integrity": "sha512-b9nW2+kT9Jl/tfzJmvzpnS6F8ziC62TDx04a7kZDtuaVA5rKKTTlLDg8ZamCRFjjnuwuFhLnzxO34N0KfeTqHg==",
+      "dependencies": {
+        "@sentry/core": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.1.tgz",
+      "integrity": "sha512-sjk60Gf5o9zynhWe1e0ro9uQO4OrKZ3H9xfgBf2ExgKXeMfKzYp5r2v2OKNevEde36Sr/DzlpiPj8EK67xrWPA==",
+      "dependencies": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/hub": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.1.tgz",
+      "integrity": "sha512-BWh5jUvGmzCsJtYy6EX3qA6gTOxwGhA64IEXHbzwIAnBoG+VWao3addaL77AGR9pIgAqn6ssfkX665OZa+GPGw==",
+      "dependencies": {
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.14.1.tgz",
+      "integrity": "sha512-vs/GXOu3RRT9ethdRXdiXmYF11PFViIo70Nt6RWb/vKEykHTQ0Y5IYc3GtU7aC6DKqpJ1xZkNUfgvV/q3he/Eg==",
+      "dependencies": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-PxAfrIwBci6ouHOuRsfVq1B16i92nQNV5IvlqfJIYciazVhDWJvbF52caJAPOFS1WnuQZ4zqBDMYvtnwld3JCA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CErQFbJMuhnHFKGkfIazQj5ETKoS7hG8PkoQEBt19F5QMh4+sbrJgnpIrIW8fVGtp0qKWKuIxQwD3b+1cFBozA==",
+      "dependencies": {
+        "@sentry/types": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.27",
@@ -22884,6 +23006,109 @@
         "@angular-devkit/core": "13.3.8",
         "@angular-devkit/schematics": "13.3.8",
         "jsonc-parser": "3.0.0"
+      }
+    },
+    "@sentry/angular": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-7.14.1.tgz",
+      "integrity": "sha512-GaqvZE+yYwuldyuk+Fu0gNO3HTJiu1UG5GZBszYonr9citdy6dRDF/QI97bkaJh1iKrz5w8PkiL/zxQOFmsTtw==",
+      "requires": {
+        "@sentry/browser": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.14.1.tgz",
+      "integrity": "sha512-b9nW2+kT9Jl/tfzJmvzpnS6F8ziC62TDx04a7kZDtuaVA5rKKTTlLDg8ZamCRFjjnuwuFhLnzxO34N0KfeTqHg==",
+      "requires": {
+        "@sentry/core": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.14.1.tgz",
+      "integrity": "sha512-sjk60Gf5o9zynhWe1e0ro9uQO4OrKZ3H9xfgBf2ExgKXeMfKzYp5r2v2OKNevEde36Sr/DzlpiPj8EK67xrWPA==",
+      "requires": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/hub": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.14.1.tgz",
+      "integrity": "sha512-BWh5jUvGmzCsJtYy6EX3qA6gTOxwGhA64IEXHbzwIAnBoG+VWao3addaL77AGR9pIgAqn6ssfkX665OZa+GPGw==",
+      "requires": {
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.14.1.tgz",
+      "integrity": "sha512-vs/GXOu3RRT9ethdRXdiXmYF11PFViIo70Nt6RWb/vKEykHTQ0Y5IYc3GtU7aC6DKqpJ1xZkNUfgvV/q3he/Eg==",
+      "requires": {
+        "@sentry/hub": "7.14.1",
+        "@sentry/types": "7.14.1",
+        "@sentry/utils": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.14.1.tgz",
+      "integrity": "sha512-PxAfrIwBci6ouHOuRsfVq1B16i92nQNV5IvlqfJIYciazVhDWJvbF52caJAPOFS1WnuQZ4zqBDMYvtnwld3JCA=="
+    },
+    "@sentry/utils": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.14.1.tgz",
+      "integrity": "sha512-CErQFbJMuhnHFKGkfIazQj5ETKoS7hG8PkoQEBt19F5QMh4+sbrJgnpIrIW8fVGtp0qKWKuIxQwD3b+1cFBozA==",
+      "requires": {
+        "@sentry/types": "7.14.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@ngrx/effects": "^14.1.0",
     "@ngrx/store": "^14.1.0",
     "@ngrx/store-devtools": "^14.1.0",
+    "@sentry/angular": "^7.14.1",
+    "@sentry/tracing": "^7.14.1",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",
     "luxon": "^2.5.0",

--- a/projects/app/src/index.html
+++ b/projects/app/src/index.html
@@ -26,5 +26,8 @@
 </head>
 <body>
   <tm-root></tm-root>
+  <script>
+      window.SENTRY_DSN = "@SENTRY_DSN@";
+  </script>
 </body>
 </html>

--- a/projects/app/src/main.ts
+++ b/projects/app/src/main.ts
@@ -1,8 +1,28 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import * as Sentry from '@sentry/angular';
+import { BrowserTracing } from '@sentry/tracing';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import version from 'generated/version.json';
+
+const SENTRY_DSN: string = (window as any).SENTRY_DSN;
+
+Sentry.init({
+  dsn: SENTRY_DSN === '@SENTRY_DSN@' ? undefined : SENTRY_DSN,
+  release: version.gitInfo.hash,
+  environment: environment.production ? 'production' : 'development',
+  integrations: [
+    new BrowserTracing({
+      tracingOrigins: [/^\/api/],
+      routingInstrumentation: Sentry.routingInstrumentation,
+    }),
+  ],
+
+  // Capture 1% of traces in production
+  tracesSampleRate: environment.production ? 0.01 : 1.0,
+});
 
 if (environment.production) {
   enableProdMode();

--- a/projects/core/src/lib/core.module.ts
+++ b/projects/core/src/lib/core.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core';
 import { ViewerAppComponent } from './pages';
 import { MapModule } from '@tailormap-viewer/map';
 import { StoreModule } from '@ngrx/store';
@@ -18,6 +18,8 @@ import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { SecurityInterceptor } from './interceptors/security.interceptor';
 import { ApplicationMapModule } from './map/application-map.module';
 import { FilterModule } from './filter/filter.module';
+import { Router } from '@angular/router';
+import * as Sentry from '@sentry/angular';
 
 const getBaseHref = (platformLocation: PlatformLocation): string => {
   return platformLocation.getBaseHrefFromDOM();
@@ -57,6 +59,9 @@ const getBaseHref = (platformLocation: PlatformLocation): string => {
     { provide: TAILORMAP_API_V1_SERVICE, useClass: TailormapApiV1Service },
     { provide: ICON_SERVICE_ICON_LOCATION, useValue: 'assets/core/imgs/' },
     { provide: APP_BASE_HREF, useFactory: getBaseHref, deps: [PlatformLocation] },
+    { provide: ErrorHandler, useValue: Sentry.createErrorHandler({ showDialog: false }) },
+    { provide: Sentry.TraceService, deps: [Router] },
+    { provide: APP_INITIALIZER, useFactory: () => () => {}, deps: [Sentry.TraceService], multi: true },
   ],
 })
 export class CoreModule {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,7 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "target": "es2020",
     "module": "es2020",
     "lib": [


### PR DESCRIPTION
This adds two secrets to the GitHub Actions: `VIEWER_SENTRY_DSN` and `API_SENTRY_DSN`.

Sentry DSN is injected into `index.html` to be able to include errors that happen while initializing Angular (e.g. `tailormap-api` unavailable).

resolves HTM-322, HTM-466