### PR TITLE
[HTM-516] Build platform independent images

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -156,12 +156,13 @@ jobs:
 
       - name: 'Create GitHub deployment'
         if: success()
-        uses: chrnorm/deployment-action@releases/v1
+        uses: chrnorm/deployment-action@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          target_url: "https://${{ secrets.DEPLOY_HOST_SNAPSHOT }}${{ env.BASE_HREF}}"
+          environment-url: "https://${{ secrets.DEPLOY_HOST_SNAPSHOT }}${{ env.BASE_HREF}}"
+          description: "Deployment for ${{ env.VERSION_TAG }}"
           environment: ${{ env.VERSION_TAG }}
-          initial_status: success
+          initial-status: success
           ref: "${{ env.GITHUB_HEAD_REF }}"
 
 

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -101,9 +101,6 @@ jobs:
           echo "VERSION_TAG=pr-${PR}" >> $GITHUB_ENV
           echo "BASE_HREF=/pull-request/${PR}/${GITHUB_REF_NAME_SLUG_URL}/" >> $GITHUB_ENV
 
-      - name: 'Build and tag docker image'
-        run: docker compose build web db
-
       - name: 'Log in to GitHub container registry'
         uses: docker/login-action@v2
         with:
@@ -111,8 +108,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Push images to registry'
-        run: docker compose push web db
+      - name: 'Build, tag and push images to registry'
+        run: |
+          docker buildx create --use --name tailormap-builder
+          docker run --privileged --rm tonistiigi/binfmt --install all
+          docker buildx build --pull --build-arg VERSION=${VERSION_TAG} --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-config-db:${VERSION_TAG} ./docker/db --push
+          docker buildx build --pull --build-arg VERSION=${VERSION_TAG} --build-arg BASE_HREF=${BASE_HREF} --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-viewer:${VERSION_TAG} . --push
 
       - name: 'Set Docker context for deployment'
         uses: arwynfr/actions-docker-context@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note when updating this version also update the version in the workflow files
-FROM node:16.18.0 AS builder
+FROM --platform=$BUILDPLATFORM node:16.18.0 AS builder
 
 ARG BASE_HREF=/
 
@@ -10,9 +10,6 @@ COPY ./package-lock.json /app
 RUN npm install
 
 COPY . /app
-
-# Disabled for now because of runtime -- GitHub Actions job runs tests in parallel
-#RUN npm run test
 
 RUN npm run build -- --base-href=${BASE_HREF}
 
@@ -41,6 +38,7 @@ COPY docker/web/configure-sentry.sh /docker-entrypoint.d/99-configure-sentry.sh
 
 # set-up timezone
 RUN set -eux;ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone \
+    && apk upgrade --update && apk -U add --no-cache tzdata \
     # update curl for CVE-2022-32221, CVE-2022-42915 and CVE-2022-42916,  \
     # can be probably removed when upgrading to > nginx:1.23.2-alpine
     && apk add --no-cache curl=7.83.1-r4 libcurl=7.83.1-r4

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Run `npm run test` to execute the unit tests via [Jest](https://jestjs.io).
 ## Building docker images
 
 Use below commands to build and push the cross-platform Docker images to the GitHub container registry.
-Please see Docker documentation for more information: https://docs.docker.com/build/building/multi-platform/
+Please see Docker documentation for more information:
+[Building multi-platform images](https://docs.docker.com/build/building/multi-platform/)
 
 ```shell
 # install QEMU architectures
@@ -47,11 +48,12 @@ docker buildx create --use --name tailormap-builder
 docker run --privileged --rm tonistiigi/binfmt --install all
 # version of the docker image. This is also the version of the application
 VERSION=snapshot
+BASE_HREF=/
 # build and push config-db and viewer images
 docker buildx build --pull --build-arg VERSION=${VERSION} \
       --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-config-db:${VERSION} \
       ./docker/db --push
-docker buildx build --pull --build-arg VERSION=${VERSION} \
+docker buildx build --pull --build-arg VERSION=${VERSION} --build-arg BASE_HREF=${BASE_HREF} \
       --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-viewer:${VERSION} \
       . --push
 ```

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ For a specific version:
 ```
 export VERSION_TAG=10.0.0-rc1
 export RELEASE_VERSION=${VERSION_TAG}
-docker pull ghcr.io/b3partners/tailormap-config-db:${VERSION_TAG}
-docker pull ghcr.io/b3partners/tailormap-viewer:${VERSION_TAG}
 docker compose --profile http --profile full up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This project is an Angular frontend for Tailormap.
 
+## Development requirements
+
+The following are required for successfully building Tailormap viewer:
+- NodeJS 16.18 (https://nodejs.org/en/)
+- npm 8 (included with NodeJS)
+- Docker (https://docs.docker.com/engine/install/) including Buildx and Compose v2 (https://docs.docker.com/compose/install/)
+
 ## Development server
 
 Run `npm run start` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
@@ -28,6 +35,27 @@ Run `npm run build` to build the project. The build artifacts will be stored in 
 ## Running unit tests
 
 Run `npm run test` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Building docker images
+
+Use below commands to build and push the cross-platform Docker images to the GitHub container registry.
+Please see Docker documentation for more information: https://docs.docker.com/build/building/multi-platform/
+
+```shell
+# install QEMU architectures
+docker buildx create --use --name tailormap-builder
+docker run --privileged --rm tonistiigi/binfmt --install all
+# version of the docker image. This is also the version of the application
+VERSION=snapshot
+# build and push config-db and viewer images
+docker buildx build --pull --build-arg VERSION=${VERSION} \
+      --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-config-db:${VERSION} \
+      ./docker/db --push
+docker buildx build --pull --build-arg VERSION=${VERSION} \
+      --platform linux/amd64,linux/arm64 -t ghcr.io/b3partners/tailormap-viewer:${VERSION} \
+      . --push
+```
+If you want to see what is going on you can add `--progress plain` in there.
 
 ## Running with Docker Compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.9'
 
+# This compose file is geared towards Continuous Integration. It can be used as a base for production.
 # See README.md for usage details
 
 networks:
@@ -7,14 +8,13 @@ networks:
     name: tailormap-viewer
 
 
+volumes:
+  config-db:
+
+
 services:
   web:
     image: ghcr.io/b3partners/tailormap-viewer:${VERSION_TAG:-snapshot}
-    build:
-      context: .
-      args:
-        - "BASE_HREF=${BASE_HREF:-/}"
-        - "VERSION=${VERSION_TAG:-snapshot}"
     profiles:
       - http
     ports:
@@ -37,11 +37,6 @@ services:
   # The same as web, but without port 80 exposed and with labels for using with Traefik as a reverse proxy.
   web-proxied:
     image: ghcr.io/b3partners/tailormap-viewer:${VERSION_TAG:-snapshot}
-    build:
-      context: .
-      args:
-        - "BASE_HREF=${BASE_HREF:-/}"
-        - "VERSION=${VERSION_TAG:-snapshot}"
     profiles:
       - proxied
     networks:
@@ -100,6 +95,8 @@ services:
     labels:
       traefik.enable: false
     restart: unless-stopped
+    depends_on:
+      - db
 
 
   admin:
@@ -113,14 +110,12 @@ services:
     labels:
       traefik.enable: false
     restart: unless-stopped
+    depends_on:
+      - db
 
 
   db:
     image: ghcr.io/b3partners/tailormap-config-db:${RELEASE_VERSION:-snapshot}
-    build:
-      context: docker/db
-      args:
-        - "VERSION=${RELEASE_VERSION:-snapshot}"
     profiles:
       - full
     networks:
@@ -139,7 +134,3 @@ services:
       retries: 5
       test: pg_isready
     restart: unless-stopped
-
-
-volumes:
-  config-db:


### PR DESCRIPTION
This brings us `linux/amd` and `linux/arm64` docker images

- [x] [HTM-525] Document how to build multiplatform images using buildx
- [x] [HTM-524] Update CI compose files
- [x] [HTM-526] Update GH action workflows to build/push multiplatform images 
- [x] Update release documentation

resolves [HTM-516]

[HTM-525]: https://b3partners.atlassian.net/browse/HTM-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-516]: https://b3partners.atlassian.net/browse/HTM-516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-526]: https://b3partners.atlassian.net/browse/HTM-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[HTM-524]: https://b3partners.atlassian.net/browse/HTM-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ