### PR TITLE
Bump NodeJS from 16.x to 18.x

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,7 +1,7 @@
 name: 'Test and deploy'
 
 env: # Keep this in sync with Dockerfile version
-  NODE_VERSION: "16.18.0"
+  NODE_VERSION: "18.12.1"
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Note when updating this version also update the version in the workflow files
-FROM --platform=$BUILDPLATFORM node:16.18.0 AS builder
+FROM --platform=$BUILDPLATFORM node:18.12.1 AS builder
 
 ARG BASE_HREF=/
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Angular frontend for Tailormap.
 ## Development requirements
 
 The following are required for successfully building Tailormap viewer:
-- NodeJS 16.18 (https://nodejs.org/en/)
+- NodeJS 18.x (https://nodejs.org/en/); the current LTS
 - npm 8 (included with NodeJS)
 - Docker (https://docs.docker.com/engine/install/) including Buildx and Compose v2 (https://docs.docker.com/compose/install/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@types/geojson": "^7946.0.10",
         "@types/jest": "^27.4.0",
         "@types/luxon": "^3.0.1",
-        "@types/node": "^16.11.7",
+        "@types/node": "^18.11.9",
         "@types/proj4": "^2.5.2",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
@@ -5064,9 +5064,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-      "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -23541,9 +23541,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.45.tgz",
-      "integrity": "sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==",
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/geojson": "^7946.0.10",
     "@types/jest": "^27.4.0",
     "@types/luxon": "^3.0.1",
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.11.9",
     "@types/proj4": "^2.5.2",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",


### PR DESCRIPTION
18.x is the current LTS version and the viewer-admin is already using that: https://github.com/B3Partners/tailormap-admin/blob/aba65eace4612210cbf5888d743a48101feb55e0/pom.xml#L122-L123

resolves HTM-564