### PR TITLE
shared: fix autofocus behavior if something else is already focused

### DIFF
--- a/projects/shared/src/lib/directives/auto-focus.directive.ts
+++ b/projects/shared/src/lib/directives/auto-focus.directive.ts
@@ -29,6 +29,11 @@ export class AutoFocusDirective implements OnChanges {
     }
 
     AutoFocusDirective.timeout = window.setTimeout(() => {
+      if (document.activeElement !== null && document.activeElement !== document.body) {
+        // something else already has focus
+        return;
+      }
+
       if (this.isSelectElement()) {
         this.el.nativeElement.select();
         return;


### PR DESCRIPTION
This should fix the login dialog test failing if it starts typing around 300ms after being initialized, and should stop autofocus from taking over if something else is already focused.

However, this isn't quite functional yet:
If e.g. the search button is clicked, *it* takes focus. I suspect that having one autofocus directive for both
"page load" focus and "new element appeared" focus might not be the best move.

Also the 300 ms timeout is a bit arbitrary :)

example failure:

```
 FAIL  projects/core/src/lib/pages/login/login-form/login-form.component.spec.ts (5.35 s)
  ● LoginFormComponent › triggers login method

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: "my_username", "p@ssw0rd"
    Received: "my_username@ssw0rd", "p"

    Number of calls: 1
```