### PR TITLE
app: disable Sentry session tracking

### DIFF
--- a/projects/app/src/main.ts
+++ b/projects/app/src/main.ts
@@ -25,6 +25,7 @@ const setupSentryProviders = async () => {
     ],
     // Capture 1% of traces in production
     tracesSampleRate: environment.production ? 0.01 : 1.0,
+    autoSessionTracking: false,
   });
   return [
     { provide: ErrorHandler, useValue: sentry.createErrorHandler({ showDialog: false }) },


### PR DESCRIPTION
Due to how the bookmarks are generated, any time the user moves the map or zooms in/out is considered a new "session" to Sentry. As we don't use it for usage tracking, disable session tracking and only depend on the random 1% error tracking.