### PR TITLE
[HTM-538] F - Location search in ESPG:3857 viewer zooms to EPSG:4326 coordinates

### DIFF
--- a/projects/core/src/lib/components/toolbar/simple-search/simple-search.component.spec.ts
+++ b/projects/core/src/lib/components/toolbar/simple-search/simple-search.component.spec.ts
@@ -7,7 +7,6 @@ import { SimpleSearchService } from './simple-search.service';
 import { MapService, ProjectionCodesEnum } from '@tailormap-viewer/map';
 import userEvent from '@testing-library/user-event';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
-import { FeatureStylingHelper } from '../../../shared/helpers/feature-styling.helper';
 
 const setup = async () => {
   const mockedSearchService = {

--- a/projects/core/src/lib/components/toolbar/simple-search/simple-search.component.ts
+++ b/projects/core/src/lib/components/toolbar/simple-search/simple-search.component.ts
@@ -1,12 +1,14 @@
-import { Component, OnInit, ChangeDetectionStrategy, inject, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { concatMap, Observable, of, startWith, Subject, tap, timer } from 'rxjs';
 import { SearchResult, SearchResultModel, SimpleSearchService } from './simple-search.service';
-import { debounceTime, filter, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { debounceTime, filter, takeUntil, withLatestFrom, switchMap } from 'rxjs/operators';
 import { MapService } from '@tailormap-viewer/map';
 import { FeatureStylingHelper } from '../../../shared/helpers/feature-styling.helper';
+import { FeatureHelper } from '../../../../../../map/src/lib/helpers/feature.helper';
+import { FeatureModel } from '@tailormap-viewer/api';
 
-type SearchStatusType = 'empty'|'no_results'|'searching'|'belowMinLength'|'complete';
+type SearchStatusType = 'empty' | 'no_results' | 'searching' | 'belowMinLength' | 'complete';
 
 @Component({
   selector: 'tm-simple-search',
@@ -16,20 +18,15 @@ type SearchStatusType = 'empty'|'no_results'|'searching'|'belowMinLength'|'compl
 })
 export class SimpleSearchComponent implements OnInit, OnDestroy {
 
+  private static readonly SEARCH_DEBOUNCE_TIME = 1000;
   public active = false;
   public minLength = 4;
   public searchControl = new FormControl<string | SearchResult>('');
-
   private searchResultsSubject = new Subject<SearchResultModel | null>();
   public searchResults$: Observable<SearchResultModel | null> = this.searchResultsSubject.asObservable();
-
   private searchStatusSubject = new Subject<SearchStatusType>();
   public searchStatus$: Observable<SearchStatusType> = this.searchStatusSubject.asObservable();
-
   private destroyed = new Subject();
-
-  private static readonly SEARCH_DEBOUNCE_TIME = 1000;
-
   private searchService = inject(SimpleSearchService);
   private mapService = inject(MapService);
 
@@ -89,14 +86,23 @@ export class SimpleSearchComponent implements OnInit, OnDestroy {
       pointType: 'circle',
       pointStrokeWidth: 0,
     });
-    this.mapService.renderFeatures$('search-result-highlight', of({
+    const feature$: Observable<FeatureModel> = of({
       __fid: 'search-result-highlight-feature',
       geometry: searchResult.geometry,
       crs: searchResult.projectionCode,
       attributes: {},
-    }), style, true, true).pipe(
-      takeUntil(timer(5000)),
-    ).subscribe();
+    });
+
+    feature$.pipe(
+      withLatestFrom(this.mapService.getProjectionCode$()),
+      switchMap(([ feature, projectionCode ]) => {
+        if (feature.geometry && feature.crs && feature.crs !== projectionCode) {
+          feature.geometry = FeatureHelper.transformGeometry(feature.geometry, feature.crs, projectionCode);
+          feature.crs = projectionCode;
+        }
+        return this.mapService.renderFeatures$('search-result-highlight', of(feature), style, true, true);
+      }),
+      takeUntil(timer(5000))).subscribe();
   }
 
 }

--- a/projects/map/src/lib/helpers/feature.helper.spec.ts
+++ b/projects/map/src/lib/helpers/feature.helper.spec.ts
@@ -3,7 +3,6 @@ import { FeatureHelper } from './feature.helper';
 import { MapUnitEnum } from '../models/map-unit.enum';
 import { Projection } from 'ol/proj';
 import { ProjectionsHelper } from './projections.helper';
-import { ProjectionCodesEnum } from '@tailormap-viewer/map';
 
 const projection = {
   getUnits: () => MapUnitEnum.m,
@@ -49,16 +48,19 @@ describe('FeatureTypesHelper', () => {
     expect(FeatureHelper.transformGeometry('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))', 'EPSG:3857', 'EPSG:3857')).toBe('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))');
   });
 
-  test('checks transformGeometry polygon from ProjectionCodesEnum.RD to EPSG:3857', () => {
-    ProjectionsHelper.initProjection(ProjectionCodesEnum.RD,
+  test('checks transformGeometry polygon from EPSG:28992 to EPSG:3857', () => {
+    ProjectionsHelper.initProjection('EPSG:28992',
       // eslint-disable-next-line max-len
       '+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m +no_defs');
     // eslint-disable-next-line max-len
     const wktGeom = 'POLYGON ((131104 460577, 129823 461804, 129495 462130, 128732 461629, 128944 461027, 129420 460143, 129722 459834, 129823 459563, 130115 459450, 130698 458799, 130791 458756, 131164 459552, 131574 460125, 131104 460577))';
     // transformed to EPSG:3857 using postgis
-    // eslint-disable-next-line max-len
-    // POLYGON((560849.2581363895 6824187.345771471,558756.4678094786 6826177.236152881,558220.3448005843 6826706.020960536,556983.7628036102 6825882.722527874,557333.6419826547 6824903.165435475,558114.9992614571 6823466.3175152205,558608.5089436477 6822965.239498022,558774.9233316716 6822524.435377617,559250.4864285775 6822342.685742314,560203.2990491522 6821286.592399324,560354.787083448 6821217.268622127,560954.7970522561 6822517.280664146,561616.8607501892 6823454.284349732,560849.2581363895 6824187.345771471))
-    expect(FeatureHelper.transformGeometry(wktGeom, ProjectionCodesEnum.RD, 'EPSG:3857')).toContain('POLYGON((560849.2581');
-    expect(FeatureHelper.transformGeometry(wktGeom, ProjectionCodesEnum.RD, 'EPSG:3857')).toContain(' 6824187.345');
+    // POLYGON((560849.2581363895 6824187.345771471,558756.4678094786 6826177.236152881,558220.3448005843 6826706.020960536,
+    //    556983.7628036102 6825882.722527874,557333.6419826547 6824903.165435475,558114.9992614571 6823466.3175152205,
+    //    558608.5089436477 6822965.239498022,558774.9233316716 6822524.435377617,559250.4864285775 6822342.685742314,
+    //    560203.2990491522 6821286.592399324,560354.787083448 6821217.268622127,560954.7970522561 6822517.280664146,
+    //    561616.8607501892 6823454.284349732,560849.2581363895 6824187.345771471))
+    expect(FeatureHelper.transformGeometry(wktGeom, 'EPSG:28992', 'EPSG:3857')).toContain('POLYGON((560849.2581');
+    expect(FeatureHelper.transformGeometry(wktGeom, 'EPSG:28992', 'EPSG:3857')).toContain(' 6824187.345');
   });
 });

--- a/projects/map/src/lib/helpers/feature.helper.spec.ts
+++ b/projects/map/src/lib/helpers/feature.helper.spec.ts
@@ -2,6 +2,8 @@ import { Circle, Point } from 'ol/geom';
 import { FeatureHelper } from './feature.helper';
 import { MapUnitEnum } from '../models/map-unit.enum';
 import { Projection } from 'ol/proj';
+import { ProjectionsHelper } from './projections.helper';
+import { ProjectionCodesEnum } from '@tailormap-viewer/map';
 
 const projection = {
   getUnits: () => MapUnitEnum.m,
@@ -31,5 +33,32 @@ describe('FeatureTypesHelper', () => {
 
   test('checks getWKT() for non-standard but not linearized circle with maximum number of decimals for meter units of measure', () => {
     expect(FeatureHelper.getWKT(new Circle([ 1.3496582958, 3.12345 ], 3.12345), projection, false)).toBe('CIRCLE(1.35 3.12 3.12)');
+  });
+
+  test('checks transformGeometry point from EPSG:4326 to EPSG:3857', () => {
+    expect(FeatureHelper.transformGeometry('POINT(1 2)', 'EPSG:4326', 'EPSG:3857')).toContain('POINT(111319.4907');
+    expect(FeatureHelper.transformGeometry('POINT(1 2)', 'EPSG:4326', 'EPSG:3857')).toContain(' 222684.2085');
+  });
+
+  test('checks transformGeometry polygon from EPSG:4326 to EPSG:3857', () => {
+    expect(FeatureHelper.transformGeometry('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))', 'EPSG:4326', 'EPSG:3857')).toContain('POLYGON((111319.4907');
+    expect(FeatureHelper.transformGeometry('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))', 'EPSG:4326', 'EPSG:3857')).toContain(' 222684.2085');
+  });
+
+  test('checks transformGeometry polygon to same crs', () => {
+    expect(FeatureHelper.transformGeometry('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))', 'EPSG:3857', 'EPSG:3857')).toBe('POLYGON ((1 2, 1 3, 2 3, 1 3, 1 2))');
+  });
+
+  test('checks transformGeometry polygon from ProjectionCodesEnum.RD to EPSG:3857', () => {
+    ProjectionsHelper.initProjection(ProjectionCodesEnum.RD,
+      // eslint-disable-next-line max-len
+      '+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m +no_defs');
+    // eslint-disable-next-line max-len
+    const wktGeom = 'POLYGON ((131104 460577, 129823 461804, 129495 462130, 128732 461629, 128944 461027, 129420 460143, 129722 459834, 129823 459563, 130115 459450, 130698 458799, 130791 458756, 131164 459552, 131574 460125, 131104 460577))';
+    // transformed to EPSG:3857 using postgis
+    // eslint-disable-next-line max-len
+    // POLYGON((560849.2581363895 6824187.345771471,558756.4678094786 6826177.236152881,558220.3448005843 6826706.020960536,556983.7628036102 6825882.722527874,557333.6419826547 6824903.165435475,558114.9992614571 6823466.3175152205,558608.5089436477 6822965.239498022,558774.9233316716 6822524.435377617,559250.4864285775 6822342.685742314,560203.2990491522 6821286.592399324,560354.787083448 6821217.268622127,560954.7970522561 6822517.280664146,561616.8607501892 6823454.284349732,560849.2581363895 6824187.345771471))
+    expect(FeatureHelper.transformGeometry(wktGeom, ProjectionCodesEnum.RD, 'EPSG:3857')).toContain('POLYGON((560849.2581');
+    expect(FeatureHelper.transformGeometry(wktGeom, ProjectionCodesEnum.RD, 'EPSG:3857')).toContain(' 6824187.345');
   });
 });

--- a/projects/map/src/lib/helpers/feature.helper.ts
+++ b/projects/map/src/lib/helpers/feature.helper.ts
@@ -114,4 +114,20 @@ export class FeatureHelper {
     return geom.transform(sourceProjection, mapProjection);
   }
 
+  /**
+   * Transforms a WKT geometry from one projection to another.
+   *
+   * @param wktGeom WKT of the geometry to transform
+   * @param sourceProjection The projection of the geometry, eg. 'EPSG:28992'
+   * @param targetProjection The projection to transform to, eg. 'EPSG:4326'
+   */
+  public static transformGeometry(wktGeom: string, sourceProjection: string, targetProjection: string): string {
+    if (!sourceProjection || !targetProjection || sourceProjection === targetProjection) {
+      return wktGeom;
+    }
+    const geom = FeatureHelper.wktFormatter.readGeometry(wktGeom, { dataProjection: sourceProjection });
+    geom.transform(sourceProjection, targetProjection);
+    return FeatureHelper.wktFormatter.writeGeometry(geom);
+  }
+
 }


### PR DESCRIPTION
- [x] Add a utility to transform a WKT geometry string to a different projection
- [x] reproject location search result to map/view projection

fixes HTM-538