### PR TITLE
[HTM-727] Disallow blank username and group name

### DIFF
--- a/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.html
+++ b/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.html
@@ -18,7 +18,7 @@
 </form>
 
 <mat-toolbar>
-  <button (click)="addOrUpdate()" color="primary" i18n mat-button mat-flat-button>{{existingGroup ? 'Update' : 'Add'}}</button>
+  <button (click)="addOrUpdate()"  [disabled]="!groupdetailsForm.valid" color="primary" i18n mat-button mat-flat-button>{{existingGroup ? 'Update' : 'Add'}}</button>
   <button (click)="clearForm()" color="primary" i18n mat-button mat-flat-button>Cancel</button>
   <button (click)="delete()" color="primary" disabled="{{!existingGroup}}" i18n mat-button mat-flat-button>Delete</button>
 </mat-toolbar>

--- a/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.spec.ts
+++ b/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.spec.ts
@@ -21,9 +21,13 @@ const setup = async () => {
 };
 describe('GroupdetailsFormComponent', () => {
 
-  test('should render', async () => {
+  test('should render with Add/Delete button disabled', async () => {
     await setup();
     expect(screen.getByText('Group Details'));
+    expect(screen.getByText('Add'));
+    expect(screen.getByText('Add').parentNode).toHaveProperty('disabled', true);
+    expect(screen.getByText('Delete'));
+    expect(screen.getByText('Delete').parentNode).toHaveProperty('disabled', true);
   });
 
 });

--- a/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.ts
+++ b/projects/admin-core/src/lib/useradmin/groupdetails-form/groupdetails-form.component.ts
@@ -14,7 +14,10 @@ export class GroupdetailsFormComponent implements OnInit, OnDestroy {
   public existingGroup = false;
 
   public groupdetailsForm = new FormGroup({
-    name: new FormControl<string>('', { nonNullable: true, validators: Validators.required }),
+    name: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [ Validators.required, Validators.pattern('[a-zA-Z0-9]*') ],
+    }),
     description: new FormControl<string>('', { nonNullable: false }),
     notes: new FormControl<string>('', { nonNullable: false }),
     systemGroup: new FormControl<boolean>(false, { nonNullable: true }),

--- a/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.html
+++ b/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.html
@@ -1,5 +1,5 @@
 <h3 i18n>User Details</h3>
-<form [formGroup]="userdetailsForm" class="userdetails-wrapper">
+<form [formGroup]="userdetailsForm" class="userdetails-wrapper" autocomplete="off">
   <div>
     <mat-form-field>
       <mat-label i18n>Username</mat-label>
@@ -39,7 +39,7 @@
 </form>
 
 <mat-toolbar>
-  <button (click)="addOrUpdate()" color="primary" i18n mat-button mat-flat-button>{{existingUser ? 'Update' : 'Add'}}</button>
+  <button (click)="addOrUpdate()" [disabled]="!userdetailsForm.valid" color="primary" i18n mat-button mat-flat-button>{{existingUser ? 'Update' : 'Add'}}</button>
   <button (click)="clearForm()" color="primary" i18n mat-button mat-flat-button>Cancel</button>
   <button (click)="delete()" color="primary" disabled="{{!existingUser}}" i18n mat-button mat-flat-button>Delete</button>
 </mat-toolbar>

--- a/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.spec.ts
+++ b/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.spec.ts
@@ -22,9 +22,12 @@ const setup = async () => {
 };
 
 describe('UserdetailsFormComponent', () => {
-  test('should render', async () => {
+  test('should render with Add/Delete button disabled', async () => {
     await setup();
+    expect(screen.getByText('User Details'));
+    expect(screen.getByText('Add'));
+    expect(screen.getByText('Add').parentNode).toHaveProperty('disabled', true);
     expect(screen.getByText('Delete'));
+    expect(screen.getByText('Delete').parentNode).toHaveProperty('disabled', true);
   });
-
 });

--- a/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.ts
+++ b/projects/admin-core/src/lib/useradmin/userdetails-form/userdetails-form.component.ts
@@ -14,7 +14,9 @@ import { formatDate } from '@angular/common';
 })
 export class UserdetailsFormComponent implements OnInit, OnDestroy {
   public userdetailsForm = new FormGroup({
-    username: new FormControl<string>('', { nonNullable: true, validators: Validators.required }),
+    username: new FormControl<string>('', {
+      nonNullable: true, validators: [ Validators.required, Validators.pattern('[a-zA-Z0-9]*') ],
+    }),
     password: new FormControl<string>('', { nonNullable: true, validators: Validators.minLength(8) }),
     confirmedPassword: new FormControl<string>('', { nonNullable: true, validators: Validators.minLength(8) }),
     email: new FormControl<string>('', { nonNullable: false, validators: Validators.email }),


### PR DESCRIPTION
also disallow strange (non-alfa-numeric) characters, only `[a-zA-Z0-9]*` are allowed, the Add/Save button is disabled when the form data is invalid.

resolves HTM-727