### PR TITLE
Set "_blank" as default target for links

### DIFF
--- a/projects/app/src/index.html
+++ b/projects/app/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Tailormap</title>
-  <base href="/">
+  <base href="/" target="_blank">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="apple-touch-icon" sizes="57x57" href="apple-icon-57x57.png">
   <link rel="apple-touch-icon" sizes="60x60" href="apple-icon-60x60.png">


### PR DESCRIPTION
So we don't have to specify this manually for every link. Useful for links in attributions, feature info, etc.

I don't think it will interfere in the normal functionality in our single-page app.