### PR TITLE
[HTM-849] Display friendly error messages when creating service

### DIFF
--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
@@ -37,7 +37,7 @@ export class TailormapAdminApiV1MockService implements TailormapAdminApiV1Servic
     return of(node).pipe(delay(this.delay));
   }
 
-  public createGeoService$(params: { geoService: GeoServiceModel }, _refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel> {
+  public createGeoService$(params: { geoService: GeoServiceModel; refreshCapabilities: boolean }): Observable<GeoServiceWithLayersModel> {
     return of({ ...params.geoService, layers: [] }).pipe(delay(this.delay));
   }
 

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-mock.service.ts
@@ -37,7 +37,7 @@ export class TailormapAdminApiV1MockService implements TailormapAdminApiV1Servic
     return of(node).pipe(delay(this.delay));
   }
 
-  public createGeoService$(params: { geoService: GeoServiceModel }): Observable<GeoServiceWithLayersModel> {
+  public createGeoService$(params: { geoService: GeoServiceModel }, _refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel> {
     return of({ ...params.geoService, layers: [] }).pipe(delay(this.delay));
   }
 

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
@@ -9,7 +9,7 @@ export interface TailormapAdminApiV1ServiceModel {
   getGeoService$(params: { id: string }): Observable<GeoServiceWithLayersModel>;
   getGeoServices$(params: { ids: string[] }): Observable<GeoServiceWithLayersModel[]>;
   getAllGeoServices$(params: { excludingIds: string[] }): Observable<GeoServiceWithLayersModel[]>;
-  createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id' | 'type'> }): Observable<GeoServiceWithLayersModel>;
+  createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id' | 'type'> }, refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel>;
   updateGeoService$(params: { id: string; geoService: Omit<Partial<GeoServiceModel>, 'type'> }): Observable<GeoServiceWithLayersModel>;
   deleteGeoService$(params: { id: string }): Observable<boolean>;
   refreshGeoService$(params: { id: string }): Observable<GeoServiceWithLayersModel>;

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1-service.model.ts
@@ -9,7 +9,7 @@ export interface TailormapAdminApiV1ServiceModel {
   getGeoService$(params: { id: string }): Observable<GeoServiceWithLayersModel>;
   getGeoServices$(params: { ids: string[] }): Observable<GeoServiceWithLayersModel[]>;
   getAllGeoServices$(params: { excludingIds: string[] }): Observable<GeoServiceWithLayersModel[]>;
-  createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id' | 'type'> }, refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel>;
+  createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id' | 'type'>; refreshCapabilities: boolean}): Observable<GeoServiceWithLayersModel>;
   updateGeoService$(params: { id: string; geoService: Omit<Partial<GeoServiceModel>, 'type'> }): Observable<GeoServiceWithLayersModel>;
   deleteGeoService$(params: { id: string }): Observable<boolean>;
   refreshGeoService$(params: { id: string }): Observable<GeoServiceWithLayersModel>;

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
@@ -56,7 +56,7 @@ export class TailormapAdminApiV1Service implements TailormapAdminApiV1ServiceMod
   }
 
   public createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id'> }): Observable<GeoServiceWithLayersModel> {
-    return this.httpClient.post<GeoServiceWithLayersModel>(`${TailormapAdminApiV1Service.BASE_URL}/geo-services`, params.geoService)
+    return this.httpClient.post<GeoServiceWithLayersModel>(`${TailormapAdminApiV1Service.BASE_URL}/geo-services`, { ...params.geoService, refreshCapabilities: true })
       .pipe(map(CatalogModelHelper.addTypeToGeoServiceModel));
   }
 

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
@@ -55,8 +55,8 @@ export class TailormapAdminApiV1Service implements TailormapAdminApiV1ServiceMod
       .pipe(map(response => (response?._embedded?.['geo-services'] || []).map(CatalogModelHelper.addTypeToGeoServiceModel)));
   }
 
-  public createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id'> }): Observable<GeoServiceWithLayersModel> {
-    return this.httpClient.post<GeoServiceWithLayersModel>(`${TailormapAdminApiV1Service.BASE_URL}/geo-services`, { ...params.geoService, refreshCapabilities: true })
+  public createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id'> }, refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel> {
+    return this.httpClient.post<GeoServiceWithLayersModel>(`${TailormapAdminApiV1Service.BASE_URL}/geo-services`, { ...params.geoService, refreshCapabilities })
       .pipe(map(CatalogModelHelper.addTypeToGeoServiceModel));
   }
 

--- a/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
+++ b/projects/admin-api/src/lib/services/tailormap-admin-api-v1.service.ts
@@ -55,9 +55,14 @@ export class TailormapAdminApiV1Service implements TailormapAdminApiV1ServiceMod
       .pipe(map(response => (response?._embedded?.['geo-services'] || []).map(CatalogModelHelper.addTypeToGeoServiceModel)));
   }
 
-  public createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id'> }, refreshCapabilities: boolean): Observable<GeoServiceWithLayersModel> {
-    return this.httpClient.post<GeoServiceWithLayersModel>(`${TailormapAdminApiV1Service.BASE_URL}/geo-services`, { ...params.geoService, refreshCapabilities })
-      .pipe(map(CatalogModelHelper.addTypeToGeoServiceModel));
+  public createGeoService$(params: { geoService: Omit<GeoServiceModel, 'id'>; refreshCapabilities: boolean}): Observable<GeoServiceWithLayersModel> {
+    return this.httpClient.post<GeoServiceWithLayersModel>(
+      `${TailormapAdminApiV1Service.BASE_URL}/geo-services`,
+      {
+        ...params.geoService,
+        refreshCapabilities: params.refreshCapabilities,
+      },
+    ).pipe(map(CatalogModelHelper.addTypeToGeoServiceModel));
   }
 
   public updateGeoService$(params: { id: string; geoService: GeoServiceModel }): Observable<GeoServiceWithLayersModel> {

--- a/projects/admin-core/src/lib/catalog/feature-source-form-dialog/feature-source-form-dialog.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-source-form-dialog/feature-source-form-dialog.component.ts
@@ -57,7 +57,9 @@ export class FeatureSourceFormDialogComponent {
       .pipe(takeUntil(this.destroyed))
       .subscribe(result => {
         this.savingSubject.next(false);
-        this.dialogRef.close(result);
+        if(result) {
+          this.dialogRef.close(result);
+        }
       });
   }
 

--- a/projects/admin-core/src/lib/catalog/geo-service-form-dialog/geo-service-form-dialog.component.ts
+++ b/projects/admin-core/src/lib/catalog/geo-service-form-dialog/geo-service-form-dialog.component.ts
@@ -63,7 +63,9 @@ export class GeoServiceFormDialogComponent {
       .pipe(takeUntil(this.destroyed))
       .subscribe(result => {
         this.savingSubject.next(false);
-        this.dialogRef.close(result);
+        if (result) {
+          this.dialogRef.close(result);
+        }
       });
   }
 
@@ -76,7 +78,9 @@ export class GeoServiceFormDialogComponent {
       .pipe(takeUntil(this.destroyed))
       .subscribe(result => {
         this.savingSubject.next(false);
-        this.dialogRef.close(result);
+        if (result) {
+          this.dialogRef.close(result);
+        }
       });
   }
 

--- a/projects/admin-core/src/lib/catalog/geo-service-layer-form-dialog/geo-service-layer-form-dialog.component.ts
+++ b/projects/admin-core/src/lib/catalog/geo-service-layer-form-dialog/geo-service-layer-form-dialog.component.ts
@@ -70,7 +70,9 @@ export class GeoServiceLayerFormDialogComponent {
       .pipe(takeUntil(this.destroyed))
       .subscribe(result => {
         this.savingSubject.next(false);
-        this.dialogRef.close(result);
+        if (result) {
+          this.dialogRef.close(result);
+        }
       });
   }
 

--- a/projects/admin-core/src/lib/catalog/helpers/geo-service.helper.ts
+++ b/projects/admin-core/src/lib/catalog/helpers/geo-service.helper.ts
@@ -19,4 +19,11 @@ export class GeoServiceHelper {
     return layerName;
   }
 
+  public static getApiErrorMessage(error: any) {
+    if (error.name === 'HttpErrorResponse' && Array.isArray(error.error?.errors)) {
+      return error.error.errors.map((e: { entity: string; property: string; invalidValue: string; message: string }) => e.message).join(", ");
+    } else {
+      return error + "";
+    }
+  }
 }

--- a/projects/admin-core/src/lib/catalog/services/geo-service.service.ts
+++ b/projects/admin-core/src/lib/catalog/services/geo-service.service.ts
@@ -90,7 +90,7 @@ export class GeoServiceService {
         },
       },
     };
-    return this.adminApiService.createGeoService$({ geoService: geoServiceModel }, true).pipe(
+    return this.adminApiService.createGeoService$({ geoService: geoServiceModel, refreshCapabilities: true }).pipe(
       catchError((errorResponse) => {
         const message = GeoServiceHelper.getApiErrorMessage(errorResponse);
         this.adminSnackbarService.showMessage($localize `Error while creating geo service: ${message}`);
@@ -146,7 +146,7 @@ export class GeoServiceService {
           return this.adminApiService.deleteGeoService$({ id: geoServiceId }).pipe(
             catchError((errorResponse) => {
               const message = GeoServiceHelper.getApiErrorMessage(errorResponse);
-              this.adminSnackbarService.showMessage($localize `Error while deleting geo service: ` + message);
+              this.adminSnackbarService.showMessage($localize `Error while deleting geo service: ${message}`);
               return of(null);
             }),
             tap(success => {

--- a/projects/admin-core/src/lib/shared/services/admin-snackbar.service.ts
+++ b/projects/admin-core/src/lib/shared/services/admin-snackbar.service.ts
@@ -15,7 +15,7 @@ export class AdminSnackbarService {
   public showMessage(msg?: string) {
     return SnackBarMessageComponent.open$(this.snackBar, {
       message: msg || 'Saved',
-      duration: 3000,
+      duration: msg ? 8000 : 5000,
       showDuration: true,
       showCloseButton: true,
     });


### PR DESCRIPTION
Requires https://github.com/B3Partners/tailormap-api/pull/516

When creating or refreshing a geo service with an invalid URI like:
- `not a url`
- `ftp://google.com/`
- `https://offline.invalid`
- `https://google.com:1337`
- `https://google.com/`
An error message will be shown in the snackbar.

Some errors are only returned when refreshing capabilities, but you can't save an invalid URL so there is an error message shown for the first one when saving an existing service with that URL value.