### PR TITLE
[HTM-890] WebGL support

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -78,8 +78,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2.5mb",
-                  "maximumError": "3mb"
+                  "maximumWarning": "3mb",
+                  "maximumError": "3.5mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18168,7 +18168,8 @@
         "geotiff": "^2.0.7",
         "ol-mapbox-style": "^10.1.0",
         "pbf": "3.2.1",
-        "rbush": "^3.0.1"
+        "rbush": "^3.0.1",
+        "spectorjs": "^0.9.27"
       },
       "funding": {
         "type": "opencollective",
@@ -18183,6 +18184,22 @@
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
         "ol": "^7.3.0"
+      }
+    },
+    "node_modules/ol-mapbox-style/node_modules/ol": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-7.4.0.tgz",
+      "integrity": "sha512-bgBbiah694HhC0jt8ptEFNRXwgO8d6xWH3G97PCg4bmn9Li5nLLbi59oSrvqUI6VPVwonPQF1YcqJymxxyMC6A==",
+      "dependencies": {
+        "earcut": "^2.2.3",
+        "geotiff": "^2.0.7",
+        "ol-mapbox-style": "^10.1.0",
+        "pbf": "3.2.1",
+        "rbush": "^3.0.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
       }
     },
     "node_modules/on-finished": {
@@ -20686,6 +20703,11 @@
       "bin": {
         "specificity": "bin/specificity"
       }
+    },
+    "node_modules/spectorjs": {
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/spectorjs/-/spectorjs-0.9.29.tgz",
+      "integrity": "sha512-WYbtN+uNR8g6Sr002VbaC6upZJPmwKSBD2SSMhjwWRkGbWSOhKSokeQXz5c+OGsbj/KrWcoz37g2NGttI5PJRw=="
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -35993,7 +36015,8 @@
         "geotiff": "^2.0.7",
         "ol-mapbox-style": "^10.1.0",
         "pbf": "3.2.1",
-        "rbush": "^3.0.1"
+        "rbush": "^3.0.1",
+        "spectorjs": "^0.9.27"
       }
     },
     "ol-mapbox-style": {
@@ -36004,6 +36027,20 @@
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
         "ol": "^7.3.0"
+      },
+      "dependencies": {
+        "ol": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/ol/-/ol-7.4.0.tgz",
+          "integrity": "sha512-bgBbiah694HhC0jt8ptEFNRXwgO8d6xWH3G97PCg4bmn9Li5nLLbi59oSrvqUI6VPVwonPQF1YcqJymxxyMC6A==",
+          "requires": {
+            "earcut": "^2.2.3",
+            "geotiff": "^2.0.7",
+            "ol-mapbox-style": "^10.1.0",
+            "pbf": "3.2.1",
+            "rbush": "^3.0.1"
+          }
+        }
       }
     },
     "on-finished": {
@@ -37840,6 +37877,11 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
+    },
+    "spectorjs": {
+      "version": "0.9.29",
+      "resolved": "https://registry.npmjs.org/spectorjs/-/spectorjs-0.9.29.tgz",
+      "integrity": "sha512-WYbtN+uNR8g6Sr002VbaC6upZJPmwKSBD2SSMhjwWRkGbWSOhKSokeQXz5c+OGsbj/KrWcoz37g2NGttI5PJRw=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/projects/map/src/lib/helpers/ol-layer-types.helper.ts
+++ b/projects/map/src/lib/helpers/ol-layer-types.helper.ts
@@ -2,30 +2,43 @@ import BaseLayer from 'ol/layer/Base';
 import VectorLayer from 'ol/layer/Vector';
 import ImageLayer from 'ol/layer/Image';
 import TileLayer from 'ol/layer/Tile';
+import WebGLTileLayer from 'ol/layer/WebGLTile';
 import Geometry from 'ol/geom/Geometry';
 import VectorSource from 'ol/source/Vector';
 import ImageWMS from 'ol/source/ImageWMS';
 import WMTS from 'ol/source/WMTS';
 import XYZ from 'ol/source/XYZ';
 import TileWMS from 'ol/source/TileWMS';
+import TileImage from 'ol/source/TileImage';
+import DataTile from 'ol/source/DataTile';
+
+/**
+ * Wrapper around WebGLTileLayer that makes getSource typed.
+ */
+export interface TypedWebGLTileLayer<T extends (TileImage | DataTile)> extends WebGLTileLayer {
+    getSource(): T | null;
+}
+
+export type CanvasOrWebGLTileLayer<T extends TileImage> = TileLayer<T> | TypedWebGLTileLayer<T>;
 
 export const isOpenLayersVectorLayer = (layer: BaseLayer): layer is VectorLayer<VectorSource<Geometry>> => {
   return layer instanceof VectorLayer;
 };
 
-export const isOpenLayersWMSLayer = (layer: BaseLayer): layer is ImageLayer<ImageWMS> | TileLayer<TileWMS> => {
+export const isOpenLayersWMSLayer = (layer: BaseLayer): layer is ImageLayer<ImageWMS> | CanvasOrWebGLTileLayer<TileWMS> => {
   return layer instanceof ImageLayer && layer.getSource() instanceof ImageWMS
-    || layer instanceof TileLayer && layer.getSource() instanceof TileWMS;
+    || (layer instanceof TileLayer || layer instanceof WebGLTileLayer) && layer.getSource() instanceof TileWMS;
 };
 
-export const isOpenLayersWMTSLayer = (layer: BaseLayer): layer is TileLayer<WMTS> => {
-  return layer instanceof TileLayer && layer.getSource() instanceof WMTS;
+export const isOpenLayersWMTSLayer = (layer: BaseLayer): layer is CanvasOrWebGLTileLayer<WMTS> => {
+  return (layer instanceof TileLayer || layer instanceof WebGLTileLayer) && layer.getSource() instanceof WMTS;
+
 };
 
-export const isOpenLayersTMSLayer = (layer: BaseLayer): layer is TileLayer<XYZ> => {
-  return layer instanceof TileLayer && layer.getSource() instanceof XYZ;
+export const isOpenLayersTMSLayer = (layer: BaseLayer): layer is CanvasOrWebGLTileLayer<XYZ> => {
+  return (layer instanceof TileLayer || layer instanceof WebGLTileLayer) && layer.getSource() instanceof XYZ;
 };
 
-export const isPossibleRealtimeLayer = (layer: BaseLayer): layer is TileLayer<XYZ> | ImageLayer<ImageWMS> => {
+export const isPossibleRealtimeLayer = (layer: BaseLayer): layer is CanvasOrWebGLTileLayer<XYZ> | ImageLayer<ImageWMS> => {
   return isOpenLayersTMSLayer(layer) || isOpenLayersWMSLayer(layer);
 };

--- a/projects/map/src/lib/helpers/ol-layer.helper.ts
+++ b/projects/map/src/lib/helpers/ol-layer.helper.ts
@@ -178,6 +178,7 @@ export class OlLayerHelper {
     const source = new WMTS(options);
     return new (OlLayerHelper.isWebGLCapable() ? WebGLTileLayer : TileLayer)({
       visible: layer.visible,
+      cacheSize: 128,
       source,
     }) as CanvasOrWebGLTileLayer<WMTS>;
   }
@@ -278,6 +279,7 @@ export class OlLayerHelper {
       });
       return new (OlLayerHelper.isWebGLCapable() ? WebGLTileLayer : TileLayer)({
         visible: layer.visible,
+        cacheSize: 128,
         source,
       }) as CanvasOrWebGLTileLayer<TileWMS>;
     }

--- a/projects/map/src/lib/models/layer-manager.model.ts
+++ b/projects/map/src/lib/models/layer-manager.model.ts
@@ -3,13 +3,20 @@ import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import { Geometry } from 'ol/geom';
 import ImageLayer from 'ol/layer/Image';
-import TileLayer from 'ol/layer/Tile';
 import ImageWMS from 'ol/source/ImageWMS';
 import WMTS from 'ol/source/WMTS';
 import XYZ from 'ol/source/XYZ';
 import { TileWMS } from 'ol/source';
 
-export type LayerTypes = VectorLayer<VectorSource<Geometry>> | TileLayer<TileWMS> | ImageLayer<ImageWMS> | TileLayer<XYZ> | TileLayer<WMTS> | null;
+import { CanvasOrWebGLTileLayer } from '../helpers/ol-layer-types.helper';
+
+export type LayerTypes =
+  VectorLayer<VectorSource<Geometry>>
+  | CanvasOrWebGLTileLayer<TileWMS>
+  | ImageLayer<ImageWMS>
+  | CanvasOrWebGLTileLayer<XYZ>
+  | CanvasOrWebGLTileLayer<WMTS>
+  | null;
 
 export interface LayerManagerModel {
   setBackgroundLayers(layers: LayerModel[]): void;

--- a/proxy.config.js
+++ b/proxy.config.js
@@ -3,7 +3,7 @@ const useLocalhost = process.env.PROXY_USE_LOCALHOST === 'true';
 
 module.exports = {
   "/api/*":{
-    "target": useLocalhost ? "http://127.0.0.1:8080" : "https://snapshot.tailormap.nl",
+    "target": useLocalhost ? "http://127.0.0.1:8083" : "https://snapshot.tailormap.nl",
     "secure": false,
     "logLevel": "info",
     "headers": useLocalhost ? {} : {


### PR DESCRIPTION
This enables (optional) WebGL support on the tile-based layers. If WebGL is disabled, it falls back to normal rendering. Vector layers, as well as ImageLayer-based rendering (used for untiled WMS), still use canvas.

Compared to the canvas renderer, if a WebGL tile is partially overlapped due to only some of the tiles of a higher zoom level being loaded, it's not properly clipped but instead overlaps the two tiles, showing both zoom levels simultaneously for transparent layers. Fixing this would require a small-ish patch to OpenLayers.

resolves HTM-890