### PR TITLE
[HTM-683] Disable cleanup of untagged docker images

### DIFF
--- a/.github/workflows/cleanup-and-maintainance.yml
+++ b/.github/workflows/cleanup-and-maintainance.yml
@@ -6,46 +6,46 @@ on:
     - cron: '19 17 * * MON'
 
 jobs:
-  dockercleanup:
-    runs-on: ubuntu-latest
-    name: "Pruning Untagged Images of ${{ matrix.containers }}"
-    strategy:
-      matrix:
-        containers: [ 'tailormap-viewer', 'tailormap-config-db', 'tailormap']
-    steps:
-      - name: 'Untagged older than 1 week, keeping last 2'
-        # https://github.com/marketplace/actions/ghcr-pruning
-        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
-        with:
-          token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          organization: B3Partners
-          container: ${{ matrix.containers }}
-          dry-run: false
-          keep-younger-than: 7
-          keep-last: 2
-          prune-untagged: true
-
-      - name: 'All untagged older than 4 weeks'
-        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
-        with:
-          token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          organization: B3Partners
-          container: ${{ matrix.containers }}
-          dry-run: false
-          keep-younger-than: 28
-          keep-last: 0
-          prune-untagged: true
-
-      - name: 'Tagged PRs older than 4 weeks'
-        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
-        with:
-          token: ${{ secrets.GHCR_CLEANUP_PAT }}
-          organization: B3Partners
-          container: ${{ matrix.containers }}
-          dry-run: false
-          keep-younger-than: 28
-          keep-last: 0
-          prune-tags-regexes: ^pr-
+#  dockercleanup:
+#    runs-on: ubuntu-latest
+#    name: "Pruning Untagged Images of ${{ matrix.containers }}"
+#    strategy:
+#      matrix:
+#        containers: [ 'tailormap-viewer', 'tailormap-config-db', 'tailormap']
+#    steps:
+#      - name: 'Untagged older than 1 week, keeping last 2'
+#        # https://github.com/marketplace/actions/ghcr-pruning
+#        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
+#        with:
+#          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+#          organization: B3Partners
+#          container: ${{ matrix.containers }}
+#          dry-run: false
+#          keep-younger-than: 7
+#          keep-last: 2
+#          prune-untagged: true
+#
+#      - name: 'All untagged older than 4 weeks'
+#        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
+#        with:
+#          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+#          organization: B3Partners
+#          container: ${{ matrix.containers }}
+#          dry-run: false
+#          keep-younger-than: 28
+#          keep-last: 0
+#          prune-untagged: true
+#
+#      - name: 'Tagged PRs older than 4 weeks'
+#        uses: 'vlaurin/action-ghcr-prune@v0.5.0'
+#        with:
+#          token: ${{ secrets.GHCR_CLEANUP_PAT }}
+#          organization: B3Partners
+#          container: ${{ matrix.containers }}
+#          dry-run: false
+#          keep-younger-than: 28
+#          keep-last: 0
+#          prune-tags-regexes: ^pr-
 
 
   stale:


### PR DESCRIPTION
As it appears to be impossible to detect multi-arch untagged images

ref: https://support.github.com/ticket/personal/0/2288180