### PR TITLE
[HTM-932] Fix map shift for web mercator projection

### DIFF
--- a/projects/api/src/lib/mock-data/tailormap-api.mock-data.ts
+++ b/projects/api/src/lib/mock-data/tailormap-api.mock-data.ts
@@ -44,7 +44,7 @@ export const getCrsModel = (overrides?: Partial<CoordinateReferenceSystemModel>)
   code: 'EPSG:28992',
   // eslint-disable-next-line max-len
   definition: '+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m +no_defs',
-  area: getBoundsModel(overrides?.area),
+  bounds: getBoundsModel(overrides?.bounds),
   ...overrides,
 });
 

--- a/projects/api/src/lib/models/coordinate-reference-system.model.ts
+++ b/projects/api/src/lib/models/coordinate-reference-system.model.ts
@@ -3,5 +3,5 @@ import { BoundsModel } from './bounds.model';
 export interface CoordinateReferenceSystemModel {
   code: string;
   definition: string;
-  area?: BoundsModel;
+  bounds?: BoundsModel;
 }

--- a/projects/map/src/lib/helpers/projections.helper.ts
+++ b/projects/map/src/lib/helpers/projections.helper.ts
@@ -1,6 +1,4 @@
-import { getWidth } from 'ol/extent';
 import { register } from 'ol/proj/proj4';
-import { OpenlayersExtent } from '../models/extent.type';
 import { Proj4Helper } from './proj4.helper';
 
 export class ProjectionsHelper {
@@ -15,17 +13,6 @@ export class ProjectionsHelper {
       ProjectionsHelper.registerProjection(alias, definition);
     });
     register(Proj4Helper.proj4);
-  }
-
-  public static getResolutions(projection: string, extent: OpenlayersExtent): number[] {
-    // @todo: check this check here
-    const size: number = projection === 'EPSG:3857' ? 20 : 22;
-    const startResolution: number = getWidth(extent) / 256;
-    const resolutions: number[] = new Array(size);
-    for (let i = 0, ii = resolutions.length; i < ii; ++i) {
-      resolutions[i] = startResolution / Math.pow(2, i);
-    }
-    return resolutions;
   }
 
   private static registerProjection(projection: string, definition: string) {

--- a/projects/map/src/lib/openlayers-map/openlayers-map.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map.ts
@@ -60,6 +60,8 @@ export class OpenLayersMap implements MapViewerModel {
 
     const view = new View({
       projection: options.projection,
+      extent: options.maxExtent,
+      showFullExtent: true,
       resolutions,
     });
 

--- a/projects/map/src/lib/openlayers-map/openlayers-map.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map.ts
@@ -56,13 +56,11 @@ export class OpenLayersMap implements MapViewerModel {
     }
 
     ProjectionsHelper.initProjection(options.projection, options.projectionDefinition, options.projectionAliases);
-    const resolutions = ProjectionsHelper.getResolutions(options.projection, options.maxExtent);
 
     const view = new View({
       projection: options.projection,
       extent: options.maxExtent,
       showFullExtent: true,
-      resolutions,
     });
 
     const olMap = new OlMap({
@@ -78,7 +76,7 @@ export class OpenLayersMap implements MapViewerModel {
       collapsed: false,
     }));
 
-    this.initialExtent = options.initialExtent && options.initialExtent.length > 0
+    this.initialExtent = options.initialExtent?.length === 4
       ? options.initialExtent
       : options.maxExtent;
 

--- a/projects/map/src/lib/openlayers-map/openlayers-map.ts
+++ b/projects/map/src/lib/openlayers-map/openlayers-map.ts
@@ -56,14 +56,10 @@ export class OpenLayersMap implements MapViewerModel {
     }
 
     ProjectionsHelper.initProjection(options.projection, options.projectionDefinition, options.projectionAliases);
-    const projection = new Projection({
-      code: options.projection,
-      extent: options.maxExtent,
-    });
     const resolutions = ProjectionsHelper.getResolutions(options.projection, options.maxExtent);
 
     const view = new View({
-      projection,
+      projection: options.projection,
       resolutions,
     });
 


### PR DESCRIPTION
The OpenLayers projection was initialized with the extent set to the max extent the admin configured for the app. This is obviously wrong, but even if the app max extent was set to the EPSG:3857 extent in the admin (or the code would use the projection extent from `/api/app/.../map` member `crs.bounds`), there would be a mismatch for the latitude range (official [EPSG:3857](https://epsg.io/3857) goes from [-85.06, 85.06] but the projection extent for OL should be [-90.0, 90.0].  As a fix just use the string as projection instead of creating a new OL Projection. OL recognizes the 'EPSG:3857' string and uses the correct extent. For other projections such as EPSG:28992 this change does not seem to matter.

Also actually applies the max map view extent.

TODO:
- [x] Resolutions are still calculated from app max extent