### PR TITLE
HTM-963: Pass through environment variable to set session timeout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       - "OIDC_SHOW_FOR_VIEWER=${OIDC_SHOW_FOR_VIEWER:-false}"
       - "SENTRY_DSN=${API_SENTRY_DSN:-}"
       - "VIEWER_SENTRY_DSN=${VIEWER_SENTRY_DSN:-}"
+      # Session timeout can be changed. Default is 30 minutes. You can use values like "60m" or "4h".
+      - "SERVER_SERVLET_SESSION_TIMEOUT=${SERVER_SERVLET_SESSION_TIMEOUT:-}"
     restart: unless-stopped
     depends_on:
       - db


### PR DESCRIPTION
I've tested it works by adding it to `.env` and printing `Session.getMaxInactiveInterval()`.