### PR TITLE
Small catalog updates: allow empty feature source title, add map service label

### DIFF
--- a/projects/admin-core/assets/locale/messages.admin-core.en.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.en.xlf
@@ -227,8 +227,8 @@
       <trans-unit id="admin-core.catalog.add-folder" datatype="html">
         <source>Add folder</source>
       </trans-unit>
-      <trans-unit id="admin-core.catalog.add-service" datatype="html">
-        <source>Add service</source>
+      <trans-unit id="admin-core.catalog.add-map-service" datatype="html">
+        <source>Add map service</source>
       </trans-unit>
       <trans-unit id="admin-core.catalog.attributes" datatype="html">
         <source>Attributes</source>

--- a/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
+++ b/projects/admin-core/assets/locale/messages.admin-core.nl.xlf
@@ -301,9 +301,9 @@
         <source>Add folder</source>
         <target>Map toevoegen</target>
       </trans-unit>
-      <trans-unit id="admin-core.catalog.add-service" datatype="html">
-        <source>Add service</source>
-        <target>Service toevoegen</target>
+      <trans-unit id="admin-core.catalog.add-map-service" datatype="html">
+        <source>Add map service</source>
+        <target>Kaartservice toevoegen</target>
       </trans-unit>
       <trans-unit id="admin-core.catalog.attributes" datatype="html">
         <source>Attributes</source>

--- a/projects/admin-core/src/lib/catalog/catalog-create-buttons/catalog-create-buttons.component.html
+++ b/projects/admin-core/src/lib/catalog/catalog-create-buttons/catalog-create-buttons.component.html
@@ -4,7 +4,7 @@
 </button>
 <button color="primary" mat-flat-button (click)="addGeoService()">
   <mat-icon svgIcon="plus"></mat-icon>
-  <span i18n="@@admin-core.catalog.add-service">Add service</span>
+  <span i18n="@@admin-core.catalog.add-map-service">Add map service</span>
 </button>
 <button color="primary" mat-flat-button (click)="addFeatureSource()">
   <mat-icon svgIcon="plus"></mat-icon>

--- a/projects/admin-core/src/lib/catalog/catalog-create-buttons/catalog-create-buttons.component.spec.ts
+++ b/projects/admin-core/src/lib/catalog/catalog-create-buttons/catalog-create-buttons.component.spec.ts
@@ -90,7 +90,7 @@ describe('CatalogCreateButtonsComponent', () => {
 
   test('should open add geo service', async () => {
     const { createGeoService$ } = await setup(true);
-    await userEvent.click(await screen.findByText('Add service'));
+    await userEvent.click(await screen.findByText('Add map service'));
     expect(await screen.findByText('Create new service')).toBeInTheDocument();
     await userEvent.type(await screen.findByPlaceholderText('URL'), 'http://service.url');
     await TestSaveHelper.waitForButtonToBeEnabledAndClick('Save', 0);

--- a/projects/admin-core/src/lib/catalog/feature-source-form/feature-source-form.component.ts
+++ b/projects/admin-core/src/lib/catalog/feature-source-form/feature-source-form.component.ts
@@ -56,7 +56,7 @@ export class FeatureSourceFormComponent implements OnInit {
   public changed = new EventEmitter<FeatureSourceCreateModel | null>();
 
   public featureSourceForm = new FormGroup({
-    title: new FormControl('', { nonNullable: true }),
+    title: new FormControl<string | null>(null),
     protocol: new FormControl<FeatureSourceProtocolEnum | null>(null, { nonNullable: true }),
 
     url: new FormControl<string | null>(null),
@@ -127,7 +127,6 @@ export class FeatureSourceFormComponent implements OnInit {
   private isValidForm() {
     const values = this.featureSourceForm.getRawValue();
     return FormHelper.isValidValue(values.protocol)
-      && FormHelper.isValidValue(values.title)
       && this.featureSourceForm.dirty;
   }
 


### PR DESCRIPTION
Empty title is allowed for map services as well. By allowing empty title for WFS the title of the WFS itself will be shown in the catalog (after fix that user entered title was overwritten by WFS title).