### PR TITLE
Fix PR deployment: remove db container using YAML !reset tag

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -159,6 +159,17 @@ jobs:
         run: |
           ssh-keyscan -H ${{ secrets.DOCKER_HOSTNAME }} > $HOME/.ssh/known_hosts
 
+      # Latest Docker Compose version neededed for ci/docker-compose.pr.yml to use !reset to remove
+      # a service when merging Compose files
+      - name: Install latest Docker Compose
+        env:
+          COMPOSE_VERSION: "2.26.1"
+        run: |
+          DOCKER_CONFIG=/usr/local/lib/docker
+          sudo mkdir -p $DOCKER_CONFIG/cli-plugins
+          sudo curl -sSL https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+          docker compose version
       - name: 'Update deployment using Docker Compose'
         run: |
           docker compose up -d --pull=always --quiet-pull

--- a/ci/docker-compose.pr.yml
+++ b/ci/docker-compose.pr.yml
@@ -29,9 +29,7 @@ services:
       - "traefik.http.services.${COMPOSE_PROJECT_NAME:-tailormap}.loadbalancer.server.port=8080"
       - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME:-tailormap}-stripprefix.stripprefix.prefixes=${BASE_HREF}"
     restart: unless-stopped
+    depends_on: !reset []
 
-  db:
-    image: rwgrim/docker-noop
-    healthcheck:
-      disable: true
-    restart: no
+  # See https://docs.docker.com/compose/compose-file/13-merge/#reset-value
+  db: !reset


### PR DESCRIPTION
...instead of setting `image` for the `db` service to `rwgrim/docker-noop` which is too old for current Docker version:

```
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/rwgrim/docker-noop:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2.
```

This however requires a newer Compose plugin version than v2.23.3 installed in the [GitHub runner image](https://github.com/actions/runner-images/blob/ubuntu22/20240414.1/images/ubuntu/Ubuntu2204-Readme.md)