### PR TITLE
[HTM-1114] Feature-info text not broken properly when text in attribute is long

### DIFF
--- a/projects/core/src/lib/components/edit/edit-dialog/edit-dialog.component.css
+++ b/projects/core/src/lib/components/edit/edit-dialog/edit-dialog.component.css
@@ -35,7 +35,8 @@
   line-height: 24px;
   border-bottom: 1px solid #D8D8D8;
   padding: 15px 14px;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .row:last-of-type {

--- a/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.css
+++ b/projects/core/src/lib/components/feature-info/feature-info-dialog/feature-info-dialog.component.css
@@ -35,7 +35,8 @@
   line-height: 24px;
   border-bottom: 1px solid #D8D8D8;
   padding: 15px 14px;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: break-word;
 }
 
 .row:last-of-type {


### PR DESCRIPTION
use
```css
  word-break: normal;
  overflow-wrap: break-word;
```
instead of `word-break: break-all;`

resolves HTM-1114
