### PR TITLE
Support high DPI legends for MapServer

### DIFF
--- a/projects/map/src/lib/openlayers-map/open-layers-layer-manager.ts
+++ b/projects/map/src/lib/openlayers-map/open-layers-layer-manager.ts
@@ -2,7 +2,6 @@ import { Feature, Map as OlMap } from 'ol';
 import { Layer as BaseLayer, Vector as VectorLayer, Group as LayerGroup } from 'ol/layer';
 import { Geometry } from 'ol/geom';
 import { Vector as VectorSource, ImageWMS, WMTS, XYZ, TileWMS } from 'ol/source';
-import {  } from 'ol/layer';
 import { LayerManagerModel, LayerTypes } from '../models';
 import { OlLayerHelper } from '../helpers/ol-layer.helper';
 import { LayerModel } from '../models/layer.model';
@@ -260,6 +259,8 @@ export class OpenLayersLayerManager implements LayerManagerModel {
     if (isOpenLayersWMSLayer(layer)) {
       return layer.getSource()?.getLegendUrl(
         undefined, {
+          // Use WMS version 1.1.0 for higher GetLegendGraphic compatibility
+          VERSION: '1.1.0',
           SLD_VERSION: '1.1.0',
         },
       ) || '';

--- a/projects/shared/src/lib/components/legend-image/legend-image.component.ts
+++ b/projects/shared/src/lib/components/legend-image/legend-image.component.ts
@@ -52,16 +52,22 @@ export class LegendImageComponent {
       scaleHiDpiImage: legend.url.includes('/uploads/legend/') && !legend.url.endsWith(".svg"),
       failedToLoadMessage: `${FAILED_TO_LOAD_MESSAGE} ${legend.title}`,
     };
-    if (legend.serverType === 'geoserver' && LegendHelper.isGetLegendGraphicRequest(legend.url)) {
-      const legendOptions: GeoServerLegendOptions = {
-        fontAntiAliasing: true,
-        labelMargin: 0,
-        forceLabels: 'on',
-      };
-      legendSettings.url = LegendHelper.addGeoServerLegendOptions(legend.url, legendOptions);
-      if (window.devicePixelRatio > 1) {
-        legendOptions.dpi = 180;
-        legendSettings.srcset = LegendHelper.addGeoServerLegendOptions(legend.url, legendOptions) + ' 2x';
+    if (LegendHelper.isGetLegendGraphicRequest(legend.url)) {
+      if (legend.serverType === 'geoserver') {
+        const legendOptions: GeoServerLegendOptions = {
+          fontAntiAliasing: true,
+          labelMargin: 0,
+          forceLabels: 'on',
+        };
+        legendSettings.url = LegendHelper.addGeoServerLegendOptions(legend.url, legendOptions);
+        if (window.devicePixelRatio > 1) {
+          legendOptions.dpi = 180;
+          legendSettings.srcset = LegendHelper.addGeoServerLegendOptions(legend.url, legendOptions) + ' 2x';
+        }
+      } else if (legend.serverType === 'mapserver') {
+        const u = new URL(legend.url);
+        u.searchParams.set('MAP_RESOLUTION', '144');
+        legendSettings.srcset = u.toString() + ' 2x';
       }
     }
     this.legendSettings = legendSettings;


### PR DESCRIPTION
Requires serverType to be set to 'mapserver' (autodetect by 'mapserv' in URL, not overrideable in admin for now).