### PR TITLE
[CI] update COMPOSE_VERSION to 2.27.2

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -165,7 +165,7 @@ jobs:
       # a service when merging Compose files
       - name: Install latest Docker Compose
         env:
-          COMPOSE_VERSION: "2.26.1"
+          COMPOSE_VERSION: "2.27.2"
         run: |
           DOCKER_CONFIG=/usr/local/lib/docker
           sudo mkdir -p $DOCKER_CONFIG/cli-plugins


### PR DESCRIPTION
ideally we should get rid of this variable and use the default, see also https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md (currently at 2.27.1 which has a known problem)