### PR TITLE
Update NodeJS to 20.15.0

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,7 +1,7 @@
 name: 'Test and deploy'
 
 env: # Keep this in sync with Dockerfile version
-  NODE_VERSION: "20.14.0"
+  NODE_VERSION: "20.15.0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ ( github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release' ) && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION=snapshot
 ARG API_VERSION=snapshot
 
 # Note when updating this version also update the version in the workflow files
-FROM --platform=linux/amd64 node:20.14.0 AS builder
+FROM --platform=linux/amd64 node:20.15.0 AS builder
 
 ARG BASE_HREF=/
 


### PR DESCRIPTION
Update NodeJS to 20.15.0 in workflow and base image to 20.15.0 in Dockerfile

- [ ] **NOTE** _the docker image still needs to be [published on docker.hub](https://hub.docker.com/_/node/tags?page=&page_size=&ordering=&name=20.1)_