### PR TITLE
Consolidate the 2 Solr profiles into one

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -93,7 +93,7 @@ jobs:
       VERSION: snapshot
       COMPOSE_PROJECT_NAME: tailormap-snapshot
       COMPOSE_FILE: docker-compose.yml:docker-compose.traefik.yml:ci/docker-compose.snapshot.yml
-      COMPOSE_PROFILE: solr,solr-monitoring
+      COMPOSE_PROFILE: solr
       BASE_HREF: /
       HOST: ${{ secrets.DEPLOY_HOST_SNAPSHOT }}
       API_SENTRY_DSN: ${{ vars.API_SENTRY_DSN }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       - solr
     image: solr:9.6.1-slim
     profiles:
-      - solr-monitoring
+      - solr
     environment:
       TZ: Europe/Amsterdam
       PORT: 9854
@@ -99,5 +99,4 @@ services:
       SOLR_URL: http://solr:8983/solr/
     command:
       # this script should be in the path for the current user
-      # /opt/solr-9.5.0/prometheus-exporter/bin/solr-exporter
       - solr-exporter


### PR DESCRIPTION
When we have a solr service running we also want to be able to monitor the solr service